### PR TITLE
Fix ts path alias for $lib

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,12 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
-		"moduleResolution": "bundler"
+		"moduleResolution": "bundler",
+		"baseUrl": ".",
+		"paths": {
+			"$lib": ["src/lib"],
+			"$lib/*": ["src/lib/*"]
+		}
 	}
 	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
 	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files


### PR DESCRIPTION
## Summary
- add baseUrl and path alias for `$lib`

## Testing
- `npm run lint --silent`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6856824f4edc83278756c75b0033744d