### PR TITLE
Fix tsconfig and add prepare instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ npm install
 npm run dev
 ```
 
+If you see a TypeScript error about a missing `.svelte-kit/tsconfig.json`, run:
+
+```bash
+npm run prepare
+```
+
 ## Build
 
 ```bash

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,12 +9,7 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
-		"moduleResolution": "bundler",
-		"baseUrl": ".",
-		"paths": {
-			"$lib": ["src/lib"],
-			"$lib/*": ["src/lib/*"]
-		}
+		"moduleResolution": "bundler"
 	}
 	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
 	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files


### PR DESCRIPTION
## Summary
- remove `baseUrl` and `paths` from `tsconfig.json`
- document `npm run prepare` to generate `.svelte-kit` files

## Testing
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6856861584d08327872c8670713410cc