### PR TITLE
Add fallback for Tailwind PostCSS plugin

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,11 @@
-import tailwindcss from '@tailwindcss/postcss';
 import autoprefixer from 'autoprefixer';
+
+let tailwindcss;
+try {
+	tailwindcss = (await import('@tailwindcss/postcss')).default;
+} catch {
+	tailwindcss = (await import('tailwindcss')).default;
+}
 
 export default {
 	plugins: [tailwindcss, autoprefixer]


### PR DESCRIPTION
## Summary
- ensure PostCSS still works even if `@tailwindcss/postcss` isn't installed
- format `postcss.config.js`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856881fcfa48327a3854467ba918c2d