### PR TITLE
Replace emoji UI elements with lucide icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"eslint-plugin-svelte": "^3.9.3",
 				"globals": "^16.2.0",
 				"idb": "^8.0.3",
+				"lucide-svelte": "^0.544.0",
 				"motion": "^11.18.2",
 				"svelte-i18n": "^4.0.1"
 			},
@@ -3530,6 +3531,15 @@
 			"license": "MIT",
 			"dependencies": {
 				"es5-ext": "~0.10.2"
+			}
+		},
+		"node_modules/lucide-svelte": {
+			"version": "0.544.0",
+			"resolved": "https://registry.npmjs.org/lucide-svelte/-/lucide-svelte-0.544.0.tgz",
+			"integrity": "sha512-8kBxSivf8SJdEUJRHBpu9bRw0S/qfVK+Yfb92KQnRRBdP425RzT6aQfrIfZctG1oucPVTBQe1ZXgmth/3qVICg==",
+			"license": "ISC",
+			"peerDependencies": {
+				"svelte": "^3 || ^4 || ^5.0.0-next.42"
 			}
 		},
 		"node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"eslint-plugin-svelte": "^3.9.3",
 		"globals": "^16.2.0",
 		"idb": "^8.0.3",
+		"lucide-svelte": "^0.544.0",
 		"motion": "^11.18.2",
 		"svelte-i18n": "^4.0.1"
 	}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,6 +7,7 @@
   import { listTransition } from '$lib/actions/listTransition';
   import type { Song } from '$lib/types/song';
   import { createTabs, melt } from '@melt-ui/svelte';
+  import { Search, ChevronDown, ChevronUp, Dot } from 'lucide-svelte';
   import { get } from 'svelte/store';
 
   let query = '';
@@ -67,7 +68,16 @@
       aria-controls="songbook-filters"
     >
       <span>{$t('app.page_index')}</span>
-      <span class="text-xs text-[rgb(var(--text-secondary))]">{filtersOpen ? '▲' : '▼'}</span>
+      <span
+        class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-[rgb(var(--surface))]/80 text-[rgb(var(--text-secondary))] shadow-sm"
+        aria-hidden="true"
+      >
+        {#if filtersOpen}
+          <ChevronUp class="h-4 w-4" />
+        {:else}
+          <ChevronDown class="h-4 w-4" />
+        {/if}
+      </span>
     </button>
     <aside
       id="songbook-filters"
@@ -165,7 +175,12 @@
           {$t('app.search_placeholder')}
         </label>
         <div class="mt-2 flex items-center gap-3 rounded-2xl border-soft surface-pill px-4 py-3 shadow-inner">
-          <span>🔍</span>
+          <span
+            class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-[rgb(var(--surface))]/70 text-[rgb(var(--accent))] shadow"
+            aria-hidden="true"
+          >
+            <Search class="h-5 w-5" />
+          </span>
           <input
             id="song-search"
             class="w-full bg-transparent text-base outline-none"
@@ -187,7 +202,12 @@
       <div class="flex flex-wrap items-center justify-between gap-3">
         <div class="flex items-center gap-2 text-sm text-[rgb(var(--text-secondary))]">
           <span>{filteredSongs.length} / {availableSongs.length}</span>
-          <span>•</span>
+          <span
+            aria-hidden="true"
+            class="inline-flex h-2.5 w-2.5 items-center justify-center rounded-full bg-[rgb(var(--accent))]/20 text-[rgb(var(--accent))]"
+          >
+            <Dot class="h-2 w-2" />
+          </span>
           {#if pageFilter}
             <span>{$t('app.page_label')} {pageFilter}</span>
           {/if}


### PR DESCRIPTION
## Summary
- add lucide-svelte and swap emoji usage for vector icons in the song index view
- enhance icon styling to better match the existing glassmorphism design

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d85d4d2ecc832788be3556f1baf731