### PR TITLE
Revamp UI styling and locale initialization

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -7,122 +7,200 @@
 @layer base {
   :root {
     color-scheme: light;
-    --surface: 248 246 241;
-    --surface-subtle: 236 230 214;
-    --surface-strong: 24 33 45;
-    --text-primary: 23 32 46;
-    --text-secondary: 94 104 122;
-    --accent: 202 165 69;
-    --accent-foreground: 23 32 46;
-    --border-muted: 221 205 169;
-    --glow-primary: 11 16 32;
+    --background: 242 245 255;
+    --foreground: 14 23 42;
+    --muted: 99 111 142;
+    --muted-foreground: 142 152 182;
+    --accent: 99 102 241;
+    --accent-foreground: 255 255 255;
+    --secondary: 80 205 255;
+    --surface: 255 255 255;
+    --surface-muted: 228 233 255;
+    --surface-border: 213 222 255;
+    --shadow: 14 23 42;
   }
 
   :root[data-theme='dark'] {
     color-scheme: dark;
-    --surface: 11 16 32;
-    --surface-subtle: 20 28 45;
-    --surface-strong: 244 236 214;
-    --text-primary: 244 236 214;
-    --text-secondary: 191 178 146;
-    --accent: 210 172 82;
-    --accent-foreground: 15 20 34;
-    --border-muted: 80 94 120;
-    --glow-primary: 202 165 69;
+    --background: 7 12 24;
+    --foreground: 237 242 255;
+    --muted: 163 177 214;
+    --muted-foreground: 104 120 171;
+    --accent: 129 140 248;
+    --accent-foreground: 12 17 32;
+    --secondary: 56 189 248;
+    --surface: 19 26 48;
+    --surface-muted: 16 21 40;
+    --surface-border: 45 55 99;
+    --shadow: 3 7 18;
   }
 
   body {
-    @apply bg-[rgb(var(--surface))] text-[rgb(var(--text-primary))] min-h-screen antialiased;
-    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-family: "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    @apply bg-[rgb(var(--background))] text-[rgb(var(--foreground))] min-h-screen antialiased;
     background-image:
-      radial-gradient(circle at 15% 15%, rgb(var(--glow-primary) / 0.22), transparent 55%),
-      radial-gradient(circle at 80% 0%, rgba(202, 165, 69, 0.18), transparent 60%),
-      radial-gradient(circle at 50% 85%, rgba(29, 43, 64, 0.16), transparent 55%);
+      radial-gradient(circle at 10% 20%, rgb(var(--secondary) / 0.35), transparent 60%),
+      radial-gradient(circle at 85% 15%, rgb(var(--accent) / 0.25), transparent 55%),
+      radial-gradient(circle at 50% 80%, rgb(94 101 235 / 0.18), transparent 55%);
     background-attachment: fixed;
+    scroll-behavior: smooth;
   }
 
   ::selection {
-    background-color: rgb(var(--accent) / 0.25);
+    background-color: rgb(var(--accent) / 0.2);
     color: rgb(var(--accent-foreground));
   }
 
   a {
-    @apply text-[rgb(var(--accent))] underline-offset-4 hover:underline;
+    @apply underline-offset-4 hover:underline;
+    color: rgb(var(--accent));
+  }
+
+  ::-webkit-scrollbar {
+    width: 10px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: rgb(var(--muted-foreground) / 0.45);
+    border-radius: 9999px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: rgb(var(--surface-muted) / 0.4);
   }
 }
 
 @layer components {
-  .glass-panel {
-    background-color: rgb(var(--surface) / 0.82);
-    border: 1px solid rgb(var(--border-muted) / 0.55);
-    border-radius: 1.5rem;
-    box-shadow: 0 24px 55px -35px rgba(12, 18, 36, 0.5);
+  .app-shell {
+    position: relative;
+    min-height: 100vh;
+    overflow: hidden;
+  }
+
+  .app-shell__inner {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 3rem;
+    min-height: 100vh;
+  }
+
+  .app-shell__content {
+    @apply mx-auto w-full max-w-7xl px-4 pb-20 sm:px-6 lg:px-10;
+  }
+
+  .app-shell__glow {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background:
+      radial-gradient(circle at 20% 20%, rgb(var(--secondary) / 0.18), transparent 55%),
+      radial-gradient(circle at 80% 10%, rgb(var(--accent) / 0.24), transparent 65%),
+      radial-gradient(circle at 50% 85%, rgb(56 189 248 / 0.22), transparent 55%);
+    opacity: 0.6;
+    filter: blur(55px);
+  }
+
+  .card {
+    background: rgb(var(--surface) / 0.88);
+    border: 1px solid rgb(var(--surface-border) / 0.7);
+    border-radius: 1.75rem;
+    box-shadow: 0 28px 80px -35px rgb(var(--shadow) / 0.55);
     backdrop-filter: blur(24px);
   }
 
-  .dark .glass-panel {
-    background-color: rgb(var(--surface-subtle) / 0.85);
-    border-color: rgb(var(--border-muted) / 0.55);
-    box-shadow: 0 24px 55px -35px rgba(7, 10, 20, 0.75);
+  .card-muted {
+    background: rgb(var(--surface-muted) / 0.82);
+    border: 1px solid rgb(var(--surface-border) / 0.5);
   }
 
-  .surface-pill {
-    background-color: rgb(var(--surface) / 0.86);
+  .card-outline {
+    border: 1px solid rgb(var(--surface-border) / 0.9);
   }
 
-  .dark .surface-pill {
-    background-color: rgb(var(--surface-subtle) / 0.86);
+  .toolbar {
+    background: rgb(var(--surface) / 0.75);
+    border-radius: 9999px;
+    border: 1px solid rgb(var(--surface-border) / 0.8);
+    backdrop-filter: blur(18px);
+    box-shadow: 0 18px 45px -28px rgb(var(--shadow) / 0.4);
   }
 
-  .surface-pill:hover {
-    background-color: rgb(var(--surface) / 0.95);
+  .badge {
+    @apply inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide;
+    background: rgb(var(--surface-muted) / 0.7);
+    color: rgb(var(--muted));
   }
 
-  .dark .surface-pill:hover {
-    background-color: rgb(var(--surface-subtle) / 0.95);
+  .stat {
+    @apply flex items-center gap-3 rounded-2xl px-5 py-4;
+    background: rgb(var(--surface) / 0.85);
+    border: 1px solid rgb(var(--surface-border) / 0.65);
+    box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.35);
   }
 
-  .surface-soft {
-    background-color: rgb(var(--surface) / 0.7);
+  .btn {
+    @apply inline-flex items-center justify-center gap-2 rounded-full px-5 py-2 text-sm font-semibold transition;
   }
 
-  .dark .surface-soft {
-    background-color: rgb(var(--surface-subtle) / 0.7);
+  .btn-primary {
+    background: linear-gradient(135deg, rgb(var(--accent) / 1) 0%, rgb(var(--secondary) / 1) 100%);
+    color: rgb(var(--accent-foreground));
+    box-shadow: 0 18px 40px -20px rgb(var(--accent) / 0.65);
   }
 
-  .surface-overlay {
-    background-color: rgb(var(--surface) / 0.7);
+  .btn-primary:hover {
+    box-shadow: 0 22px 44px -18px rgb(var(--accent) / 0.75);
+    transform: translateY(-1px);
   }
 
-  .dark .surface-overlay {
-    background-color: rgb(var(--surface-subtle) / 0.72);
-  }
-
-  .backdrop-strong {
-    backdrop-filter: blur(22px);
-  }
-
-  .border-soft {
-    border: 1px solid rgb(var(--border-muted) / 0.65);
-  }
-
-  .header-border {
-    border-bottom: 1px solid rgb(var(--border-muted) / 0.45);
+  .btn-ghost {
+    background: rgb(var(--surface-muted) / 0.65);
+    color: rgb(var(--muted));
   }
 
   .chip {
-    @apply rounded-full text-xs font-medium;
-    padding: 0.35rem 0.75rem;
-    background-color: rgb(var(--surface) / 0.7);
-    color: rgb(var(--text-secondary));
+    @apply rounded-full px-3 py-1 text-xs font-medium;
+    background: rgb(var(--surface-muted) / 0.75);
+    color: rgb(var(--muted));
   }
 
-  .dark .chip {
-    background-color: rgb(var(--surface-subtle) / 0.65);
-    color: rgb(var(--text-primary));
+  .glass-line {
+    position: relative;
+    overflow: hidden;
   }
 
-  .heading-gradient {
-    @apply bg-gradient-to-r from-[#f6d77a] via-[#d7b454] to-[#8c6b25] bg-clip-text text-transparent;
+  .glass-line::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, transparent, rgb(255 255 255 / 0.3), transparent);
+    transform: translateX(-100%);
+    animation: shimmer 6s infinite;
+  }
+
+  .card-hero {
+    background: linear-gradient(135deg, rgb(var(--surface) / 0.96), rgb(var(--surface-muted) / 0.88));
+    position: relative;
+  }
+
+  .dark .card,
+  .dark .card-muted,
+  .dark .toolbar,
+  .dark .stat {
+    backdrop-filter: blur(30px);
+  }
+}
+
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  50% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(100%);
   }
 }

--- a/src/lib/actions/fadeSlide.ts
+++ b/src/lib/actions/fadeSlide.ts
@@ -1,0 +1,48 @@
+import { animate } from 'motion';
+
+type FadeSlideOptions = {
+  delay?: number;
+  axis?: 'x' | 'y';
+  from?: number;
+  stiffness?: number;
+  damping?: number;
+};
+
+const defaultOptions: Required<FadeSlideOptions> = {
+  delay: 0,
+  axis: 'y',
+  from: 32,
+  stiffness: 0.32,
+  damping: 0.85
+};
+
+export function fadeSlide(node: HTMLElement, options: FadeSlideOptions = {}) {
+  const opts = { ...defaultOptions, ...options } as Required<FadeSlideOptions>;
+  let hasAnimated = false;
+
+  const axisProperty = opts.axis === 'x' ? 'translateX' : 'translateY';
+
+  const observer = new IntersectionObserver((entries) => {
+    const entry = entries[0];
+    if (entry?.isIntersecting && !hasAnimated) {
+      hasAnimated = true;
+      animate(
+        node,
+        { opacity: [0, 1], transform: [`${axisProperty}(${opts.from}px)`, `${axisProperty}(0px)`] } as Record<string, unknown>,
+        {
+          delay: opts.delay,
+          duration: 0.55,
+          easing: 'cubic-bezier(0.16, 1, 0.3, 1)'
+        }
+      );
+    }
+  }, { threshold: 0.2 });
+
+  observer.observe(node);
+
+  return {
+    destroy() {
+      observer.disconnect();
+    }
+  };
+}

--- a/src/lib/components/layout/AppHeader.svelte
+++ b/src/lib/components/layout/AppHeader.svelte
@@ -1,63 +1,114 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { t } from 'svelte-i18n';
   import { language, theme } from '$lib/stores/preferences';
   import { isSyncing, lastSynced } from '$lib/stores/songStore';
   import { derived } from 'svelte/store';
+  import { fadeSlide } from '$lib/actions/fadeSlide';
+  import { animate } from 'motion';
+  import { Music3, Sparkles, Languages, Sun, MoonStar } from 'lucide-svelte';
 
   const syncingLabel = derived([isSyncing, lastSynced], ([$isSyncing, $lastSynced]) => {
     if ($isSyncing) return $t('app.syncing');
     if ($lastSynced) return `${$t('app.last_synced')}: ${new Date($lastSynced).toLocaleString()}`;
     return '';
   });
+
+  let heroRef: HTMLDivElement | null = null;
+
+  onMount(() => {
+    if (!heroRef) return;
+    animate(heroRef, { opacity: [0, 1], scale: [0.98, 1] }, { duration: 0.6, easing: 'ease-out' });
+  });
 </script>
 
-<header class="sticky top-0 z-40 header-border surface-overlay backdrop-strong">
-  <div class="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-4 sm:px-6 lg:flex-row lg:items-center lg:justify-between">
-    <div class="flex w-full flex-col gap-4 lg:flex-row lg:items-center lg:gap-6">
-      <div class="flex items-center gap-3">
-        <img
-          src="/logo.svg"
-          alt="Songbook logo"
-          class="h-12 w-12 rounded-full border bg-[rgb(var(--surface))] p-1 shadow-sm"
-          style="border-color: rgb(var(--border-muted) / 0.6)"
-        />
-        <div>
-          <h1 class="text-2xl font-semibold leading-tight heading-gradient">{$t('app.title')}</h1>
-          <p class="text-sm text-[rgb(var(--text-secondary))]">{$t('app.tagline')}</p>
+<header class="relative w-full">
+  <div class="mx-auto w-full max-w-7xl px-4 pt-8 sm:px-6 lg:px-10">
+    <div class="card card-hero relative overflow-hidden" bind:this={heroRef}>
+      <div class="glass-line absolute inset-0 opacity-60" aria-hidden="true"></div>
+      <div class="relative flex flex-col gap-8 p-6 sm:p-10">
+        <div class="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+          <div class="space-y-6" use:fadeSlide={{ delay: 0 }}>
+            <div class="inline-flex items-center gap-3 rounded-full bg-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white/80 mix-blend-overlay">
+              {$t('app.brand_global')}
+            </div>
+            <div class="space-y-3">
+              <div class="inline-flex items-center gap-3 text-sm text-white/80">
+                <Music3 class="h-5 w-5" />
+                <span>{$t('app.brand_available_offline')}</span>
+              </div>
+              <h1 class="text-3xl font-semibold text-[rgb(var(--foreground))] sm:text-4xl lg:text-5xl">
+                {$t('app.title')}
+              </h1>
+              <p class="max-w-2xl text-base text-[rgb(var(--muted))] sm:text-lg">
+                {$t('app.tagline')}
+              </p>
+            </div>
+          </div>
+          <div class="toolbar flex w-full flex-col gap-4 rounded-3xl border border-white/10 bg-white/10 p-4 shadow-lg sm:flex-row sm:items-center sm:justify-end" use:fadeSlide={{ delay: 0.1 }}>
+            <div class="flex flex-1 items-center gap-3 rounded-2xl bg-white/60 px-4 py-3 text-sm font-semibold text-[rgb(var(--foreground))] shadow-sm dark:bg-white/10 dark:text-[rgb(var(--foreground))]">
+              <Languages class="h-5 w-5 text-[rgb(var(--accent))]" />
+              <label class="flex w-full items-center gap-3">
+                <span class="text-xs uppercase tracking-wide text-[rgb(var(--muted))]">
+                  {$t('app.language_label')}
+                </span>
+                <select
+                  class="w-full bg-transparent text-sm font-semibold text-[rgb(var(--foreground))] outline-none"
+                  bind:value={$language}
+                >
+                  <option value="PL">Polski</option>
+                  <option value="EN">English</option>
+                </select>
+              </label>
+            </div>
+            <div class="flex flex-1 items-center gap-3 rounded-2xl bg-white/60 px-4 py-3 text-sm font-semibold text-[rgb(var(--foreground))] shadow-sm dark:bg-white/10 dark:text-[rgb(var(--foreground))]">
+              <Sun class="h-5 w-5 text-[rgb(var(--accent))]" />
+              <label class="flex w-full items-center gap-3">
+                <span class="text-xs uppercase tracking-wide text-[rgb(var(--muted))]">
+                  {$t('app.theme_label')}
+                </span>
+                <select
+                  class="w-full bg-transparent text-sm font-semibold text-[rgb(var(--foreground))] outline-none"
+                  bind:value={$theme}
+                >
+                  <option value="light">{$t('app.light')}</option>
+                  <option value="dark">{$t('app.dark')}</option>
+                  <option value="system">{$t('app.system')}</option>
+                </select>
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" use:fadeSlide={{ delay: 0.15 }}>
+          <div class="stat">
+            <Sparkles class="h-6 w-6 text-[rgb(var(--accent))]" />
+            <div>
+              <p class="text-xs uppercase tracking-wide text-[rgb(var(--muted))]">{$t('app.brand_available_offline')}</p>
+              <p class="text-lg font-semibold text-[rgb(var(--foreground))]">{$t('app.toggle_index')}</p>
+            </div>
+          </div>
+          <div class="stat">
+            <MoonStar class="h-6 w-6 text-[rgb(var(--accent))]" />
+            <div>
+              <p class="text-xs uppercase tracking-wide text-[rgb(var(--muted))]">{$t('app.theme_label')}</p>
+              <p class="text-lg font-semibold text-[rgb(var(--foreground))]">{$t('app.system')}</p>
+            </div>
+          </div>
+          <div class="stat">
+            <Music3 class="h-6 w-6 text-[rgb(var(--accent))]" />
+            <div>
+              <p class="text-xs uppercase tracking-wide text-[rgb(var(--muted))]">{$t('app.view.basic')}</p>
+              <p class="text-lg font-semibold text-[rgb(var(--foreground))]">{$t('app.view.chords')}</p>
+            </div>
+          </div>
         </div>
       </div>
-      <div class="flex flex-wrap items-center gap-2 text-xs text-[rgb(var(--text-secondary))] lg:text-sm">
-        <span class="chip uppercase tracking-wide">{$t('app.brand_global')}</span>
-        <span class="chip uppercase tracking-wide">{$t('app.brand_available_offline')}</span>
-      </div>
-    </div>
-    <div class="flex flex-col gap-3 text-sm sm:flex-row sm:flex-wrap sm:items-center sm:justify-end">
-      <label class="flex items-center gap-2 rounded-full border border-[rgb(var(--border-muted))] surface-pill px-4 py-2 shadow-sm transition">
-        <span class="font-medium text-[rgb(var(--text-secondary))]">{$t('app.language_label')}</span>
-        <select
-          class="bg-transparent font-semibold text-[rgb(var(--text-primary))] focus:outline-none"
-          bind:value={$language}
-        >
-          <option value="PL">Polski</option>
-          <option value="EN">English</option>
-        </select>
-      </label>
-      <label class="flex items-center gap-2 rounded-full border border-[rgb(var(--border-muted))] surface-pill px-4 py-2 shadow-sm transition">
-        <span class="font-medium text-[rgb(var(--text-secondary))]">{$t('app.theme_label')}</span>
-        <select
-          class="bg-transparent font-semibold text-[rgb(var(--text-primary))] focus:outline-none"
-          bind:value={$theme}
-        >
-          <option value="light">{$t('app.light')}</option>
-          <option value="dark">{$t('app.dark')}</option>
-          <option value="system">{$t('app.system')}</option>
-        </select>
-      </label>
+      {#if $syncingLabel}
+        <div class="border-t border-white/20 bg-white/30 px-6 py-3 text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))] dark:bg-white/5">
+          {$syncingLabel}
+        </div>
+      {/if}
     </div>
   </div>
-  {#if $syncingLabel}
-    <div class="bg-[rgb(var(--surface-subtle))]/80 py-2 text-center text-xs font-medium uppercase tracking-wide text-[rgb(var(--text-secondary))]">
-      {$syncingLabel}
-    </div>
-  {/if}
 </header>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,16 +2,24 @@
   import '../app.css';
   import { browser } from '$app/environment';
   import { onMount } from 'svelte';
-  import { register, init } from 'svelte-i18n';
+  import { addMessages, init, locale as i18nLocale } from 'svelte-i18n';
   import { get } from 'svelte/store';
   import AppHeader from '$lib/components/layout/AppHeader.svelte';
   import { loadSongs } from '$lib/stores/songStore';
   import { language } from '$lib/stores/preferences';
+  import pl from '$lib/locales/pl.json';
+  import en from '$lib/locales/en.json';
 
-  register('pl', () => import('$lib/locales/pl.json'));
-  register('en', () => import('$lib/locales/en.json'));
+  addMessages('pl', pl);
+  addMessages('en', en);
 
-  init({ fallbackLocale: 'pl', initialLocale: get(language).toLowerCase() });
+  const initialLocale = (browser ? get(language) : 'PL').toLowerCase();
+
+  init({ fallbackLocale: 'pl', initialLocale });
+
+  if (!browser) {
+    i18nLocale.set(initialLocale);
+  }
 
   onMount(() => {
     loadSongs();
@@ -34,7 +42,12 @@
   });
 </script>
 
-<AppHeader />
-<main class="mx-auto min-h-[calc(100vh-6rem)] w-full max-w-7xl px-4 py-8 sm:px-6 sm:py-10">
-  <slot />
-</main>
+<div class="app-shell">
+  <div class="app-shell__inner">
+    <AppHeader />
+    <main class="app-shell__content">
+      <slot />
+    </main>
+  </div>
+  <div class="app-shell__glow" aria-hidden="true"></div>
+</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,19 +1,35 @@
 <script lang="ts">
   import { t } from 'svelte-i18n';
+  import { browser } from '$app/environment';
   import { goto } from '$app/navigation';
   import { language, favourites, viewMode, toggleFavourite } from '$lib/stores/preferences';
   import { searchableSongs, songs, filterSongs } from '$lib/stores/songStore';
   import { buildPageIndex, songsByPage } from '$lib/utils/pageIndex';
   import { listTransition } from '$lib/actions/listTransition';
+  import { fadeSlide } from '$lib/actions/fadeSlide';
   import type { Song } from '$lib/types/song';
   import { createTabs, melt } from '@melt-ui/svelte';
-  import { Search, ChevronDown, ChevronUp, Dot } from 'lucide-svelte';
+  import { onMount } from 'svelte';
+  import { Search, ChevronDown, ChevronUp, Dot, Heart, Music3, BookText } from 'lucide-svelte';
   import { get } from 'svelte/store';
 
   let query = '';
   let menuView: 'index' | 'favourites' = 'index';
   let pageFilter: number | null = null;
-  let filtersOpen = false;
+  let filtersOpen = browser ? false : true;
+  let isDesktop = false;
+
+  onMount(() => {
+    if (!browser) return;
+    const update = () => {
+      const desktop = window.innerWidth >= 1280;
+      isDesktop = desktop;
+      filtersOpen = desktop;
+    };
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  });
 
   const viewTabs = createTabs({ defaultValue: get(viewMode) });
   const { elements: viewTabElements, states: viewTabStates } = viewTabs;
@@ -59,138 +75,39 @@
   }
 </script>
 
-<section class="grid gap-6 lg:grid-cols-[320px,1fr] lg:gap-10">
-  <div class="lg:space-y-0">
-    <button
-      class="flex w-full items-center justify-between rounded-2xl border border-[rgb(var(--border-muted))] bg-[rgb(var(--surface))]/80 px-4 py-3 text-sm font-semibold text-[rgb(var(--text-primary))] shadow-sm transition hover:border-[rgb(var(--accent))] hover:text-[rgb(var(--accent))] lg:hidden"
-      on:click={() => (filtersOpen = !filtersOpen)}
-      aria-expanded={filtersOpen}
-      aria-controls="songbook-filters"
-    >
-      <span>{$t('app.page_index')}</span>
-      <span
-        class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-[rgb(var(--surface))]/80 text-[rgb(var(--text-secondary))] shadow-sm"
-        aria-hidden="true"
-      >
-        {#if filtersOpen}
-          <ChevronUp class="h-4 w-4" />
-        {:else}
-          <ChevronDown class="h-4 w-4" />
-        {/if}
-      </span>
-    </button>
-    <aside
-      id="songbook-filters"
-      class="glass-panel mt-2 p-6 transition-all lg:mt-0 lg:block"
-      class:hidden={!filtersOpen}
-    >
-    <div class="flex items-center justify-between">
-      <h2 class="text-lg font-semibold text-[rgb(var(--text-primary))]">{$t('app.page_index')}</h2>
-      <button
-        class="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--accent))] hover:underline"
-        on:click={handleClearFilters}
-      >
-        {$t('app.reset_filters')}
-      </button>
-    </div>
-    <div class="mt-4 space-y-4">
-      <div class="flex gap-2">
-        <button
-          class={`flex-1 rounded-full px-4 py-2 text-sm font-semibold transition ${
-            menuView === 'index'
-              ? 'bg-[rgb(var(--accent))] text-[rgb(var(--accent-foreground))] shadow-lg'
-              : 'surface-pill text-[rgb(var(--text-secondary))]'
-          }`}
-          on:click={() => (menuView = 'index')}
-        >
-          {$t('app.toggle_index')}
-        </button>
-        <button
-          class={`flex-1 rounded-full px-4 py-2 text-sm font-semibold transition ${
-            menuView === 'favourites'
-              ? 'bg-[rgb(var(--accent))] text-[rgb(var(--accent-foreground))] shadow-lg'
-              : 'surface-pill text-[rgb(var(--text-secondary))]'
-          }`}
-          on:click={() => (menuView = 'favourites')}
-        >
-          {$t('app.toggle_favourites')}
-        </button>
-      </div>
-
-      {#if menuView === 'favourites'}
-        {#if favouriteSongs.length === 0}
-          <p class="text-sm text-[rgb(var(--text-secondary))]">{$t('app.no_favourites')}</p>
-        {:else}
-          <ul class="space-y-3 text-sm">
-            {#each favouriteSongs as favSong (favSong.id + '-' + favSong.language)}
-              <li class="glass-panel p-3 shadow-sm">
-                <button class="text-left" on:click={() => openSong(favSong)}>
-                  <p class="font-semibold">{favSong.title}</p>
-                  <p class="text-xs text-[rgb(var(--text-secondary))]">
-                    {$t('app.page_label')} {favSong.page}
-                  </p>
-                </button>
-              </li>
-            {/each}
-          </ul>
-        {/if}
-      {:else}
-        <div class="space-y-2">
-          {#each pageGroups as group}
-            <details class="glass-panel overflow-hidden" open>
-              <summary class="flex cursor-pointer items-center justify-between px-4 py-3 text-sm font-semibold">
-                <span>{group.label}</span>
-                <span class="chip">{group.pages.length}</span>
-              </summary>
-              <div class="divide-y divide-[rgb(var(--border-muted))] px-4">
-                {#each group.pages as pageNumber}
-                  <button
-                    class={`flex w-full items-center justify-between py-2 text-left text-sm transition ${
-                      pageFilter === pageNumber
-                        ? 'text-[rgb(var(--accent))]' : 'hover:text-[rgb(var(--accent))]'
-                    }`}
-                    on:click={() => handlePageSelect(pageNumber)}
-                  >
-                    <span>
-                      {$t('app.page_label')} {pageNumber}
-                    </span>
-                    <span class="text-xs text-[rgb(var(--text-secondary))]">
-                      {(groupedByPage[pageNumber] ?? []).length}
-                    </span>
-                  </button>
-                {/each}
-              </div>
-            </details>
-          {/each}
+<section class="space-y-12">
+  <div class="card px-6 py-6 sm:px-8 sm:py-10" use:fadeSlide={{ delay: 0.05 }}>
+    <div class="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+      <div class="space-y-4">
+        <div class="inline-flex items-center gap-2 rounded-full bg-[rgb(var(--surface-muted))]/70 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">
+          <Music3 class="h-4 w-4" />
+          <span>{$t('app.search_placeholder')}</span>
         </div>
-      {/if}
-    </div>
-    </aside>
-  </div>
-
-  <section class="space-y-6">
-    <div class="glass-panel flex flex-col gap-4 p-6">
-      <div>
-        <label class="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--text-secondary))]" for="song-search">
+        <h2 class="text-2xl font-semibold text-[rgb(var(--foreground))] sm:text-3xl">
+          {$t('app.toggle_index')}
+        </h2>
+        <p class="max-w-2xl text-sm text-[rgb(var(--muted))] sm:text-base">
+          {$t('app.tagline')}
+        </p>
+      </div>
+      <div class="w-full max-w-xl space-y-3">
+        <label class="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]" for="song-search">
           {$t('app.search_placeholder')}
         </label>
-        <div class="mt-2 flex items-center gap-3 rounded-2xl border-soft surface-pill px-4 py-3 shadow-inner">
-          <span
-            class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-[rgb(var(--surface))]/70 text-[rgb(var(--accent))] shadow"
-            aria-hidden="true"
-          >
+        <div class="flex items-center gap-3 rounded-2xl border border-[rgb(var(--surface-border))/0.6] bg-white/65 px-4 py-3 shadow-inner dark:bg-white/10">
+          <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-[rgb(var(--surface-muted))]/70 text-[rgb(var(--accent))]">
             <Search class="h-5 w-5" />
           </span>
           <input
             id="song-search"
-            class="w-full bg-transparent text-base outline-none"
+            class="w-full bg-transparent text-base text-[rgb(var(--foreground))] outline-none"
             type="search"
             placeholder={$t('app.search_placeholder')}
             bind:value={query}
           />
           {#if query}
             <button
-              class="text-sm font-medium text-[rgb(var(--accent))] hover:underline"
+              class="text-sm font-semibold text-[rgb(var(--accent))] transition hover:text-[rgb(var(--accent))]/80"
               on:click={() => (query = '')}
             >
               {$t('app.clear_query')}
@@ -198,114 +115,223 @@
           {/if}
         </div>
       </div>
-
-      <div class="flex flex-wrap items-center justify-between gap-3">
-        <div class="flex items-center gap-2 text-sm text-[rgb(var(--text-secondary))]">
-          <span>{filteredSongs.length} / {availableSongs.length}</span>
-          <span
-            aria-hidden="true"
-            class="inline-flex h-2.5 w-2.5 items-center justify-center rounded-full bg-[rgb(var(--accent))]/20 text-[rgb(var(--accent))]"
-          >
-            <Dot class="h-2 w-2" />
-          </span>
-          {#if pageFilter}
-            <span>{$t('app.page_label')} {pageFilter}</span>
-          {/if}
+    </div>
+    <div class="mt-8 grid gap-4 sm:grid-cols-3" use:fadeSlide={{ delay: 0.1 }}>
+      <div class="stat">
+        <Dot class="h-5 w-5 text-[rgb(var(--accent))]" />
+        <div>
+          <p class="text-xs uppercase tracking-wide text-[rgb(var(--muted))]">{$t('app.page_index')}</p>
+          <p class="text-lg font-semibold text-[rgb(var(--foreground))]">{filteredSongs.length} / {availableSongs.length}</p>
         </div>
-        <div class="flex items-center gap-2" use:melt={$viewTabsRoot}>
-          <div class="surface-pill flex gap-2 rounded-full p-1" use:melt={$viewTabsList}>
-            <button
-              class={`rounded-full px-4 py-2 text-sm font-semibold transition ${
-                $viewTabValue === 'basic'
-                  ? 'bg-[rgb(var(--accent))] text-[rgb(var(--accent-foreground))] shadow'
-                  : 'text-[rgb(var(--text-secondary))]'
-              }`}
-              use:melt={$viewTabsTrigger({ value: 'basic' })}
-            >
-              {$t('app.view.basic')}
-            </button>
-            <button
-              class={`rounded-full px-4 py-2 text-sm font-semibold transition ${
-                $viewTabValue === 'chords'
-                  ? 'bg-[rgb(var(--accent))] text-[rgb(var(--accent-foreground))] shadow'
-                  : 'text-[rgb(var(--text-secondary))]'
-              }`}
-              use:melt={$viewTabsTrigger({ value: 'chords' })}
-            >
-              {$t('app.view.chords')}
-            </button>
-          </div>
+      </div>
+      <div class="stat">
+        <Heart class="h-5 w-5 text-[rgb(var(--accent))]" />
+        <div>
+          <p class="text-xs uppercase tracking-wide text-[rgb(var(--muted))]">{$t('app.toggle_favourites')}</p>
+          <p class="text-lg font-semibold text-[rgb(var(--foreground))]">{favouriteSongs.length}</p>
+        </div>
+      </div>
+      <div class="stat">
+        <BookText class="h-5 w-5 text-[rgb(var(--accent))]" />
+        <div>
+          <p class="text-xs uppercase tracking-wide text-[rgb(var(--muted))]">{$t('app.view_song')}</p>
+          <p class="text-lg font-semibold text-[rgb(var(--foreground))]">
+            {$viewMode === 'basic' ? $t('app.view.basic') : $t('app.view.chords')}
+          </p>
         </div>
       </div>
     </div>
+  </div>
 
-    {#if filteredSongs.length === 0}
-      <div class="glass-panel p-10 text-center text-sm text-[rgb(var(--text-secondary))]">
-        {$t('app.empty_state')}
-      </div>
-    {:else}
-      <div class="grid gap-6">
-        {#each filteredSongs as song, index (song.id + '-' + song.language)}
-          <article
-            class="glass-panel flex flex-col gap-4 p-6 transition hover:-translate-y-1 hover:shadow-2xl"
-            use:listTransition={index}
+  <div class="grid gap-10 xl:grid-cols-[320px,1fr]">
+    <div class="space-y-4 xl:space-y-6">
+      <button
+        class="toolbar flex w-full items-center justify-between rounded-full px-4 py-3 text-sm font-semibold text-[rgb(var(--foreground))] transition hover:shadow-lg xl:hidden"
+        on:click={() => (filtersOpen = !filtersOpen)}
+        aria-expanded={filtersOpen}
+        aria-controls="songbook-filters"
+      >
+        <span>{$t('app.page_index')}</span>
+        <span class="inline-flex h-7 w-7 items-center justify-center rounded-full bg-[rgb(var(--surface-muted))]/80 text-[rgb(var(--muted))]">
+          {#if filtersOpen}
+            <ChevronUp class="h-4 w-4" />
+          {:else}
+            <ChevronDown class="h-4 w-4" />
+          {/if}
+        </span>
+      </button>
+
+      <aside
+        id="songbook-filters"
+        class="card card-muted space-y-6 px-6 py-6"
+        class:hidden={!filtersOpen && !isDesktop}
+      >
+        <div class="flex items-center justify-between">
+          <h3 class="text-lg font-semibold text-[rgb(var(--foreground))]">{$t('app.page_index')}</h3>
+          <button
+            class="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--accent))] hover:underline"
+            on:click={handleClearFilters}
           >
-            <div class="flex flex-wrap items-center justify-between gap-3">
-              <div>
-                <h3 class="text-xl font-semibold text-[rgb(var(--text-primary))]">{song.title}</h3>
-                <div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-[rgb(var(--text-secondary))]">
-                  <span class="chip">{$t('app.page_label')} {song.page}</span>
-                  <span class="chip">{$t('app.source_label')} {song.source}</span>
-                  <span class="chip">{$t('app.external_index')} {song.externalIndex}</span>
+            {$t('app.reset_filters')}
+          </button>
+        </div>
+        <div class="grid gap-2 sm:grid-cols-2 xl:grid-cols-1">
+          <button
+            class={`btn ${menuView === 'index' ? 'btn-primary' : 'btn-ghost'}`}
+            on:click={() => (menuView = 'index')}
+          >
+            {$t('app.toggle_index')}
+          </button>
+          <button
+            class={`btn ${menuView === 'favourites' ? 'btn-primary' : 'btn-ghost'}`}
+            on:click={() => (menuView = 'favourites')}
+          >
+            {$t('app.toggle_favourites')}
+          </button>
+        </div>
+        {#if menuView === 'favourites'}
+          {#if favouriteSongs.length === 0}
+            <p class="rounded-2xl bg-white/60 px-4 py-3 text-sm text-[rgb(var(--muted))] dark:bg-white/10">
+              {$t('app.no_favourites')}
+            </p>
+          {:else}
+            <ul class="space-y-3 text-sm">
+              {#each favouriteSongs as favSong (favSong.id + '-' + favSong.language)}
+                <li class="card-outline rounded-2xl bg-white/70 p-4 shadow-sm transition hover:shadow-lg dark:bg-white/5">
+                  <button class="w-full text-left" on:click={() => openSong(favSong)}>
+                    <p class="text-base font-semibold text-[rgb(var(--foreground))]">{favSong.title}</p>
+                    <p class="text-xs text-[rgb(var(--muted))]">
+                      {$t('app.page_label')} {favSong.page}
+                    </p>
+                  </button>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        {:else}
+          <div class="space-y-4">
+            {#each pageGroups as group}
+              <details class="card-outline overflow-hidden rounded-2xl bg-white/60 dark:bg-white/5" open>
+                <summary class="flex cursor-pointer items-center justify-between px-4 py-3 text-sm font-semibold text-[rgb(var(--foreground))]">
+                  <span>{group.label}</span>
+                  <span class="chip">{group.pages.length}</span>
+                </summary>
+                <div class="divide-y divide-[rgb(var(--surface-border))/0.6]">
+                  {#each group.pages as pageNumber}
+                    <button
+                      class={`flex w-full items-center justify-between px-4 py-2 text-left text-sm transition ${
+                        pageFilter === pageNumber
+                          ? 'text-[rgb(var(--accent))]' : 'hover:text-[rgb(var(--accent))]'
+                      }`}
+                      on:click={() => handlePageSelect(pageNumber)}
+                    >
+                      <span>{$t('app.page_label')} {pageNumber}</span>
+                      <span class="text-xs text-[rgb(var(--muted))]">
+                        {(groupedByPage[pageNumber] ?? []).length}
+                      </span>
+                    </button>
+                  {/each}
+                </div>
+              </details>
+            {/each}
+          </div>
+        {/if}
+      </aside>
+    </div>
+
+    <section class="space-y-6">
+      <div class="toolbar flex flex-wrap items-center justify-between gap-4 rounded-3xl px-4 py-3" use:melt={$viewTabsRoot}>
+        <div class="flex items-center gap-3 text-sm text-[rgb(var(--muted))]">
+          <span class="font-semibold text-[rgb(var(--foreground))]">{filteredSongs.length}</span>
+          <span>/</span>
+          <span>{availableSongs.length}</span>
+          {#if pageFilter}
+            <span class="chip">{$t('app.page_label')} {pageFilter}</span>
+          {/if}
+        </div>
+        <div class="flex gap-2" use:melt={$viewTabsList}>
+          <button
+            class={`btn ${$viewTabValue === 'basic' ? 'btn-primary' : 'btn-ghost'}`}
+            use:melt={$viewTabsTrigger({ value: 'basic' })}
+          >
+            {$t('app.view.basic')}
+          </button>
+          <button
+            class={`btn ${$viewTabValue === 'chords' ? 'btn-primary' : 'btn-ghost'}`}
+            use:melt={$viewTabsTrigger({ value: 'chords' })}
+          >
+            {$t('app.view.chords')}
+          </button>
+        </div>
+      </div>
+
+      {#if filteredSongs.length === 0}
+        <div class="card-muted rounded-3xl px-8 py-12 text-center text-sm text-[rgb(var(--muted))]">
+          {$t('app.empty_state')}
+        </div>
+      {:else}
+        <div class="grid gap-6">
+          {#each filteredSongs as song, index (song.id + '-' + song.language)}
+            <article
+              class="card relative overflow-hidden px-6 py-6 transition hover:-translate-y-1 hover:shadow-2xl sm:px-8"
+              use:listTransition={index}
+            >
+              <div class="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-[rgb(var(--accent))] via-[rgb(var(--secondary))] to-[rgb(var(--accent))] opacity-75"></div>
+              <div class="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+                <div class="space-y-3">
+                  <h3 class="text-2xl font-semibold text-[rgb(var(--foreground))]">{song.title}</h3>
+                  <div class="flex flex-wrap items-center gap-2 text-xs text-[rgb(var(--muted))]">
+                    <span class="chip">{$t('app.page_label')} {song.page}</span>
+                    <span class="chip">{$t('app.source_label')} {song.source}</span>
+                    <span class="chip">{$t('app.external_index')} {song.externalIndex}</span>
+                  </div>
+                </div>
+                <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+                  <button
+                    class={`btn ${$favourites.includes(`${song.id}-${song.language}`) ? 'btn-primary' : 'btn-ghost'}`}
+                    on:click={() => toggleFavourite(`${song.id}-${song.language}`)}
+                  >
+                    {$favourites.includes(`${song.id}-${song.language}`)
+                      ? $t('app.remove_favourite')
+                      : $t('app.add_favourite')}
+                  </button>
+                  <button
+                    class="btn btn-primary"
+                    on:click={() => openSong(song)}
+                  >
+                    {$t('app.view_song')}
+                  </button>
                 </div>
               </div>
-              <div class="flex items-center gap-2">
-                <button
-                  class={`rounded-full px-4 py-2 text-sm font-semibold transition ${
-                    $favourites.includes(`${song.id}-${song.language}`)
-                      ? 'bg-[rgb(var(--accent))] text-[rgb(var(--accent-foreground))]'
-                      : 'surface-pill text-[rgb(var(--text-secondary))]'
-                  }`}
-                  on:click={() => toggleFavourite(`${song.id}-${song.language}`)}
-                >
-                  {$favourites.includes(`${song.id}-${song.language}`)
-                    ? $t('app.remove_favourite')
-                    : $t('app.add_favourite')}
-                </button>
-                <button
-                  class="rounded-full border border-[rgb(var(--border-muted))] px-4 py-2 text-sm font-semibold text-[rgb(var(--accent))]"
-                  on:click={() => openSong(song)}
-                >
-                  {$t('app.view_song')}
-                </button>
-              </div>
-            </div>
 
-            <div class={`space-y-1 text-[rgb(var(--text-primary))] ${$viewTabValue === 'chords' ? 'lg:grid lg:grid-cols-[180px,1fr] lg:gap-4' : ''}`}>
-              {#each song.items as item}
-                {#if item.text.trim().length}
-                  <p
-                    class={`text-sm leading-relaxed ${
-                      item.alignment === 'CENTER'
-                        ? 'text-center'
-                        : item.alignment === 'RIGHT'
-                        ? 'text-right'
-                        : 'text-left'
-                    } ${item.isBold ? 'font-semibold' : ''} ${item.isItalics ? 'italic' : ''}`}
-                  >
-                    {#if $viewTabValue === 'chords'}
-                      <span class="text-xs uppercase tracking-wide text-[rgb(var(--text-secondary))]">TAB</span>
-                      <span class="ml-3 block text-base font-medium">{item.text}</span>
-                    {:else}
-                      {item.text}
-                    {/if}
-                  </p>
-                {/if}
-              {/each}
-            </div>
-          </article>
-        {/each}
-      </div>
-    {/if}
-  </section>
+              <div class={`mt-6 space-y-2 text-[rgb(var(--foreground))] ${
+                $viewTabValue === 'chords' ? 'lg:grid lg:grid-cols-[200px,1fr] lg:gap-4' : ''
+              }`}>
+                {#each song.items as item}
+                  {#if item.text.trim().length}
+                    <p
+                      class={`text-sm leading-relaxed ${
+                        item.alignment === 'CENTER'
+                          ? 'text-center'
+                          : item.alignment === 'RIGHT'
+                          ? 'text-right'
+                          : 'text-left'
+                      } ${item.isBold ? 'font-semibold' : ''} ${item.isItalics ? 'italic' : ''}`}
+                    >
+                      {#if $viewTabValue === 'chords'}
+                        <span class="text-xs uppercase tracking-wide text-[rgb(var(--muted))]">TAB</span>
+                        <span class="ml-3 block text-base font-medium">{item.text}</span>
+                      {:else}
+                        {item.text}
+                      {/if}
+                    </p>
+                  {/if}
+                {/each}
+              </div>
+            </article>
+          {/each}
+        </div>
+      {/if}
+    </section>
+  </div>
 </section>


### PR DESCRIPTION
## Summary
- rebuild the global visual system with new gradients, components, and layout shell for a more polished experience
- redesign the header and song listing screens with animated cards, responsive filters, and motion-powered interactions
- preload translation messages during SSR to prevent missing locale errors and add a reusable fade-slide animation helper

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d9349e11d88327a599b4cb208e54d5