### PR TITLE
Refine song catalog UX with sorting and previews

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,14 @@
 			"dependencies": {
 				"@eslint/js": "^9.29.0",
 				"@melt-ui/svelte": "^0.86.6",
+				"@skeletonlabs/skeleton": "^3.2.2",
+				"@skeletonlabs/tw-plugin": "^0.4.1",
 				"@supabase/supabase-js": "^2.50.0",
 				"clsx": "^2.1.1",
 				"eslint-plugin-svelte": "^3.9.3",
 				"globals": "^16.2.0",
 				"idb": "^8.0.3",
+				"lenis": "^1.3.11",
 				"lucide-svelte": "^0.544.0",
 				"motion": "^11.18.2",
 				"svelte-i18n": "^4.0.1"
@@ -1198,6 +1201,24 @@
 			"os": [
 				"win32"
 			]
+		},
+		"node_modules/@skeletonlabs/skeleton": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@skeletonlabs/skeleton/-/skeleton-3.2.2.tgz",
+			"integrity": "sha512-dAunBAWqRMcNTGAvCKUgpADJdbtqL65eNEb7pDIKQZ6bI6qsxakR6MuF2E4B3jmUEpcaxaggDp0UdnUjlkAZ1Q==",
+			"license": "MIT",
+			"peerDependencies": {
+				"tailwindcss": "^4.0.0"
+			}
+		},
+		"node_modules/@skeletonlabs/tw-plugin": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@skeletonlabs/tw-plugin/-/tw-plugin-0.4.1.tgz",
+			"integrity": "sha512-crrC8BGKis0GNTp7V2HF6mk1ECLUvAxgTTV26LMgt/rV3U6Xd7N7dL5qIL8fE4MTHvpKa1SBsdqsnMbEvATeEg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"tailwindcss": ">=3.0.0"
+			}
 		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.0.0",
@@ -3313,6 +3334,32 @@
 			"integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
 			"license": "MIT"
 		},
+		"node_modules/lenis": {
+			"version": "1.3.11",
+			"resolved": "https://registry.npmjs.org/lenis/-/lenis-1.3.11.tgz",
+			"integrity": "sha512-lkyBnNTVwJzlupp+VL6LTn62WeT8WponuLpmTU0Z20cMwMsLLjqbSqwuA7I1yKSVWCBj/awo4jnFzOMOVCB8OQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/darkroomengineering"
+			},
+			"peerDependencies": {
+				"@nuxt/kit": ">=3.0.0",
+				"react": ">=17.0.0",
+				"vue": ">=3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@nuxt/kit": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"vue": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/levn": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4507,7 +4554,6 @@
 			"version": "4.1.13",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
 			"integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
 	},
 	"devDependencies": {
 		"@eslint/compat": "^1.3.0",
-                "@melt-ui/pp": "^0.3.2",
-                "@sveltejs/adapter-auto": "^6.0.1",
+		"@melt-ui/pp": "^0.3.2",
+		"@sveltejs/adapter-auto": "^6.0.1",
 		"@sveltejs/kit": "^2.22.0",
 		"@sveltejs/vite-plugin-svelte": "^3.1.2",
 		"@tailwindcss/postcss": "^4.1.13",
@@ -36,11 +36,14 @@
 	"dependencies": {
 		"@eslint/js": "^9.29.0",
 		"@melt-ui/svelte": "^0.86.6",
+		"@skeletonlabs/skeleton": "^3.2.2",
+		"@skeletonlabs/tw-plugin": "^0.4.1",
 		"@supabase/supabase-js": "^2.50.0",
 		"clsx": "^2.1.1",
 		"eslint-plugin-svelte": "^3.9.3",
 		"globals": "^16.2.0",
 		"idb": "^8.0.3",
+		"lenis": "^1.3.11",
 		"lucide-svelte": "^0.544.0",
 		"motion": "^11.18.2",
 		"svelte-i18n": "^4.0.1"

--- a/src/app.css
+++ b/src/app.css
@@ -1,206 +1,88 @@
-@import "tailwindcss";
-@import "tailwindcss/preflight";
-@plugin "@tailwindcss/typography";
-@reference "tailwindcss";
-@tailwind utilities;
+@import '@skeletonlabs/skeleton/styles/all.css';
+@import 'tailwindcss';
 
 @layer base {
   :root {
     color-scheme: light;
-    --background: 242 245 255;
-    --foreground: 14 23 42;
-    --muted: 99 111 142;
-    --muted-foreground: 142 152 182;
-    --accent: 99 102 241;
-    --accent-foreground: 255 255 255;
-    --secondary: 80 205 255;
-    --surface: 255 255 255;
-    --surface-muted: 228 233 255;
-    --surface-border: 213 222 255;
-    --shadow: 14 23 42;
   }
 
   :root[data-theme='dark'] {
     color-scheme: dark;
-    --background: 7 12 24;
-    --foreground: 237 242 255;
-    --muted: 163 177 214;
-    --muted-foreground: 104 120 171;
-    --accent: 129 140 248;
-    --accent-foreground: 12 17 32;
-    --secondary: 56 189 248;
-    --surface: 19 26 48;
-    --surface-muted: 16 21 40;
-    --surface-border: 45 55 99;
-    --shadow: 3 7 18;
   }
 
   body {
-    font-family: "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    @apply bg-[rgb(var(--background))] text-[rgb(var(--foreground))] min-h-screen antialiased;
+    font-family: Inter, 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    @apply bg-surface-50 text-surface-900 dark:bg-surface-900 dark:text-surface-50 min-h-screen antialiased;
     background-image:
-      radial-gradient(circle at 10% 20%, rgb(var(--secondary) / 0.35), transparent 60%),
-      radial-gradient(circle at 85% 15%, rgb(var(--accent) / 0.25), transparent 55%),
-      radial-gradient(circle at 50% 80%, rgb(94 101 235 / 0.18), transparent 55%);
+      radial-gradient(circle at 15% 20%, rgba(14, 165, 233, 0.28), transparent 60%),
+      radial-gradient(circle at 80% 10%, rgba(99, 102, 241, 0.23), transparent 55%),
+      radial-gradient(circle at 40% 85%, rgba(56, 189, 248, 0.18), transparent 55%);
     background-attachment: fixed;
-    scroll-behavior: smooth;
+  }
+
+  body.is-lenis {
+    overflow: hidden;
+  }
+
+  .lenis.lenis-smooth {
+    scroll-behavior: auto;
+  }
+
+  .lenis.lenis-smooth [data-lenis-prevent] {
+    overscroll-behavior: contain;
   }
 
   ::selection {
-    background-color: rgb(var(--accent) / 0.2);
-    color: rgb(var(--accent-foreground));
-  }
-
-  a {
-    @apply underline-offset-4 hover:underline;
-    color: rgb(var(--accent));
+    background: rgba(99, 102, 241, 0.18);
+    color: rgb(18, 21, 56);
   }
 
   ::-webkit-scrollbar {
-    width: 10px;
+    width: 12px;
   }
 
   ::-webkit-scrollbar-thumb {
-    background: rgb(var(--muted-foreground) / 0.45);
+    background: linear-gradient(135deg, rgba(99, 102, 241, 0.45), rgba(56, 189, 248, 0.35));
     border-radius: 9999px;
   }
 
   ::-webkit-scrollbar-track {
-    background: rgb(var(--surface-muted) / 0.4);
+    background: rgba(14, 23, 42, 0.08);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    html:focus-within {
+      scroll-behavior: auto;
+    }
+
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
   }
 }
 
-@layer components {
-  .app-shell {
+@layer utilities {
+  .backdrop-glass {
+    @apply bg-white/60 backdrop-blur-xl dark:bg-surface-800/80;
+  }
+
+  .gradient-border {
     position: relative;
-    min-height: 100vh;
-    overflow: hidden;
   }
 
-  .app-shell__inner {
-    position: relative;
-    z-index: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 3rem;
-    min-height: 100vh;
-  }
-
-  .app-shell__content {
-    @apply mx-auto w-full max-w-7xl px-4 pb-20 sm:px-6 lg:px-10;
-  }
-
-  .app-shell__glow {
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    background:
-      radial-gradient(circle at 20% 20%, rgb(var(--secondary) / 0.18), transparent 55%),
-      radial-gradient(circle at 80% 10%, rgb(var(--accent) / 0.24), transparent 65%),
-      radial-gradient(circle at 50% 85%, rgb(56 189 248 / 0.22), transparent 55%);
-    opacity: 0.6;
-    filter: blur(55px);
-  }
-
-  .card {
-    background: rgb(var(--surface) / 0.88);
-    border: 1px solid rgb(var(--surface-border) / 0.7);
-    border-radius: 1.75rem;
-    box-shadow: 0 28px 80px -35px rgb(var(--shadow) / 0.55);
-    backdrop-filter: blur(24px);
-  }
-
-  .card-muted {
-    background: rgb(var(--surface-muted) / 0.82);
-    border: 1px solid rgb(var(--surface-border) / 0.5);
-  }
-
-  .card-outline {
-    border: 1px solid rgb(var(--surface-border) / 0.9);
-  }
-
-  .toolbar {
-    background: rgb(var(--surface) / 0.75);
-    border-radius: 9999px;
-    border: 1px solid rgb(var(--surface-border) / 0.8);
-    backdrop-filter: blur(18px);
-    box-shadow: 0 18px 45px -28px rgb(var(--shadow) / 0.4);
-  }
-
-  .badge {
-    @apply inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide;
-    background: rgb(var(--surface-muted) / 0.7);
-    color: rgb(var(--muted));
-  }
-
-  .stat {
-    @apply flex items-center gap-3 rounded-2xl px-5 py-4;
-    background: rgb(var(--surface) / 0.85);
-    border: 1px solid rgb(var(--surface-border) / 0.65);
-    box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.35);
-  }
-
-  .btn {
-    @apply inline-flex items-center justify-center gap-2 rounded-full px-5 py-2 text-sm font-semibold transition;
-  }
-
-  .btn-primary {
-    background: linear-gradient(135deg, rgb(var(--accent) / 1) 0%, rgb(var(--secondary) / 1) 100%);
-    color: rgb(var(--accent-foreground));
-    box-shadow: 0 18px 40px -20px rgb(var(--accent) / 0.65);
-  }
-
-  .btn-primary:hover {
-    box-shadow: 0 22px 44px -18px rgb(var(--accent) / 0.75);
-    transform: translateY(-1px);
-  }
-
-  .btn-ghost {
-    background: rgb(var(--surface-muted) / 0.65);
-    color: rgb(var(--muted));
-  }
-
-  .chip {
-    @apply rounded-full px-3 py-1 text-xs font-medium;
-    background: rgb(var(--surface-muted) / 0.75);
-    color: rgb(var(--muted));
-  }
-
-  .glass-line {
-    position: relative;
-    overflow: hidden;
-  }
-
-  .glass-line::after {
-    content: "";
+  .gradient-border::before {
+    content: '';
     position: absolute;
-    inset: 0;
-    background: linear-gradient(90deg, transparent, rgb(255 255 255 / 0.3), transparent);
-    transform: translateX(-100%);
-    animation: shimmer 6s infinite;
-  }
-
-  .card-hero {
-    background: linear-gradient(135deg, rgb(var(--surface) / 0.96), rgb(var(--surface-muted) / 0.88));
-    position: relative;
-  }
-
-  .dark .card,
-  .dark .card-muted,
-  .dark .toolbar,
-  .dark .stat {
-    backdrop-filter: blur(30px);
-  }
-}
-
-@keyframes shimmer {
-  0% {
-    transform: translateX(-100%);
-  }
-  50% {
-    transform: translateX(100%);
-  }
-  100% {
-    transform: translateX(100%);
+    inset: -1px;
+    border-radius: inherit;
+    background: linear-gradient(130deg, rgba(129, 140, 248, 0.8), rgba(56, 189, 248, 0.7));
+    mask: linear-gradient(#fff, #fff) padding-box, linear-gradient(#fff, #fff);
+    mask-composite: exclude;
+    pointer-events: none;
   }
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -8,6 +8,31 @@ declare global {
                 // interface PageState {}
                 // interface Platform {}
         }
+
+        namespace svelteHTML {
+                interface HTMLAttributes<T> {
+                        'on:enterViewport'?: (event: CustomEvent<IntersectionObserverEntry>) => void;
+                        'on:exitViewport'?: (event: CustomEvent<IntersectionObserverEntry>) => void;
+                }
+        }
+}
+
+declare module 'lenis' {
+        interface LenisOptions {
+                duration?: number;
+                easing?: (t: number) => number;
+                smoothWheel?: boolean;
+                smoothTouch?: boolean;
+        }
+
+        export default class Lenis {
+                constructor(options?: LenisOptions);
+                raf(time: number): void;
+                stop(): void;
+                start(): void;
+                resize(): void;
+                destroy(): void;
+        }
 }
 
 export {};

--- a/src/lib/actions/fadeSlide.ts
+++ b/src/lib/actions/fadeSlide.ts
@@ -4,39 +4,61 @@ type FadeSlideOptions = {
   delay?: number;
   axis?: 'x' | 'y';
   from?: number;
-  stiffness?: number;
-  damping?: number;
 };
 
 const defaultOptions: Required<FadeSlideOptions> = {
   delay: 0,
   axis: 'y',
-  from: 32,
-  stiffness: 0.32,
-  damping: 0.85
+  from: 32
 };
+
+const reduceMotion = typeof window !== 'undefined'
+  ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  : false;
 
 export function fadeSlide(node: HTMLElement, options: FadeSlideOptions = {}) {
   const opts = { ...defaultOptions, ...options } as Required<FadeSlideOptions>;
   let hasAnimated = false;
 
-  const axisProperty = opts.axis === 'x' ? 'translateX' : 'translateY';
+  const initialTransform = opts.axis === 'x'
+    ? `translate3d(${opts.from}px, 0, 0)`
+    : `translate3d(0, ${opts.from}px, 0)`;
 
-  const observer = new IntersectionObserver((entries) => {
-    const entry = entries[0];
-    if (entry?.isIntersecting && !hasAnimated) {
+  node.style.opacity = hasAnimated ? '1' : '0';
+  node.style.transform = initialTransform;
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      const [entry] = entries;
+      if (!entry?.isIntersecting || hasAnimated) return;
       hasAnimated = true;
-      animate(
+
+      if (reduceMotion) {
+        node.style.opacity = '1';
+        node.style.transform = 'translate3d(0, 0, 0)';
+        observer.disconnect();
+        return;
+      }
+
+      node.style.willChange = 'transform, opacity';
+
+      const animation = animate(
         node,
-        { opacity: [0, 1], transform: [`${axisProperty}(${opts.from}px)`, `${axisProperty}(0px)`] } as Record<string, unknown>,
+        { opacity: [0, 1], transform: [initialTransform, 'translate3d(0, 0, 0)'] },
         {
           delay: opts.delay,
           duration: 0.55,
           easing: 'cubic-bezier(0.16, 1, 0.3, 1)'
         }
       );
-    }
-  }, { threshold: 0.2 });
+
+      animation.finished.finally(() => {
+        node.style.willChange = '';
+        observer.disconnect();
+      });
+    },
+    { threshold: 0.25 }
+  );
 
   observer.observe(node);
 

--- a/src/lib/actions/inView.ts
+++ b/src/lib/actions/inView.ts
@@ -1,0 +1,32 @@
+interface InViewOptions extends IntersectionObserverInit {
+  once?: boolean;
+}
+
+export function inView(node: HTMLElement, options: InViewOptions = {}) {
+  const { once = true, root = null, rootMargin = '0px', threshold = 0.15 } = options;
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      const [entry] = entries;
+      if (!entry) return;
+
+      if (entry.isIntersecting) {
+        node.dispatchEvent(new CustomEvent('enterViewport', { detail: entry }));
+        if (once) {
+          observer.disconnect();
+        }
+      } else if (!once) {
+        node.dispatchEvent(new CustomEvent('exitViewport', { detail: entry }));
+      }
+    },
+    { root, rootMargin, threshold }
+  );
+
+  observer.observe(node);
+
+  return {
+    destroy() {
+      observer.disconnect();
+    }
+  };
+}

--- a/src/lib/actions/listTransition.ts
+++ b/src/lib/actions/listTransition.ts
@@ -1,19 +1,40 @@
 import { animate } from 'motion';
 
+const reduceMotion = typeof window !== 'undefined'
+  ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  : false;
+
 export function listTransition(node: HTMLElement, index = 0) {
+  if (reduceMotion) {
+    node.style.opacity = '1';
+    node.style.transform = 'translate3d(0, 0, 0)';
+    return {
+      destroy() {}
+    };
+  }
+
+  node.style.opacity = '0';
+  node.style.transform = 'translate3d(0, 16px, 0)';
+  node.style.willChange = 'transform, opacity';
+
   const animation = animate(
     node,
-    { opacity: [0, 1], transform: ['translateY(16px)', 'translateY(0)'] } as Record<string, unknown>,
+    { opacity: [0, 1], transform: ['translate3d(0, 16px, 0)', 'translate3d(0, 0, 0)'] },
     {
       duration: 0.45,
-      delay: index * 0.05,
-      ease: 'easeOut'
+      delay: Math.min(index, 6) * 0.05,
+      easing: 'cubic-bezier(0.22, 1, 0.36, 1)'
     }
   );
+
+  animation.finished.finally(() => {
+    node.style.willChange = '';
+  });
 
   return {
     destroy() {
       animation.cancel();
+      node.style.willChange = '';
     }
   };
 }

--- a/src/lib/components/song/SongCard.svelte
+++ b/src/lib/components/song/SongCard.svelte
@@ -1,0 +1,233 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { onMount, onDestroy, createEventDispatcher } from 'svelte';
+  import { fade } from 'svelte/transition';
+  import { t } from 'svelte-i18n';
+  import { listTransition } from '$lib/actions/listTransition';
+  import { inView } from '$lib/actions/inView';
+  import { Heart, ExternalLink, Eye, EyeOff, Link2 } from 'lucide-svelte';
+  import type { Song } from '$lib/types/song';
+
+  export let song: Song;
+  export let index = 0;
+  export let viewMode: 'basic' | 'chords' = 'basic';
+  export let isFavourite = false;
+
+  const dispatch = createEventDispatcher<{
+    open: Song;
+    toggleFavourite: string;
+  }>();
+
+  let visible = false;
+  let expanded = false;
+  let copyState: 'idle' | 'copied' | 'error' = 'idle';
+  let copyTimeout: ReturnType<typeof setTimeout> | null = null;
+  let prefersReducedMotion = true;
+  let shareUrl = '';
+
+  const PREVIEW_LENGTH = 3;
+
+  $: printableItems = song.items.filter((item) => item.text.trim().length);
+  $: previewItems = printableItems.slice(0, PREVIEW_LENGTH);
+  $: remainingItems = printableItems.slice(PREVIEW_LENGTH);
+  $: totalLines = printableItems.length;
+  $: chordLines = printableItems.filter((item) => item.type === 'CHORD').length;
+  $: density = totalLines ? chordLines / totalLines : 0;
+  $: densityPercentage = Math.round(density * 100);
+  $: lastUpdatedLabel = song.lastUpdatedAt
+    ? new Date(song.lastUpdatedAt).toLocaleDateString(undefined, {
+        day: 'numeric',
+        month: 'short',
+        year: 'numeric'
+      })
+    : null;
+  $: shareUrl = browser
+    ? new URL(`/song/${song.id}?lang=${song.language}`, window.location.origin).toString()
+    : '';
+
+  function handleEnter() {
+    visible = true;
+  }
+
+  onMount(() => {
+    if (!browser) return;
+    const query = window.matchMedia('(prefers-reduced-motion: reduce)');
+    prefersReducedMotion = query.matches;
+    const handleChange = (event: MediaQueryListEvent) => {
+      prefersReducedMotion = event.matches;
+    };
+    query.addEventListener('change', handleChange);
+    return () => query.removeEventListener('change', handleChange);
+  });
+
+  onDestroy(() => {
+    if (copyTimeout) clearTimeout(copyTimeout);
+  });
+
+  async function copyShareLink() {
+    if (!browser || !shareUrl) return;
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      copyState = 'copied';
+    } catch (error) {
+      console.error('Failed to copy song link', error);
+      copyState = 'error';
+    }
+    if (copyTimeout) clearTimeout(copyTimeout);
+    copyTimeout = setTimeout(() => {
+      copyState = 'idle';
+    }, 2000);
+  }
+
+  function alignmentClass(alignment: Song['items'][number]['alignment']) {
+    if (alignment === 'CENTER') return 'text-center';
+    if (alignment === 'RIGHT') return 'text-right';
+    return 'text-left';
+  }
+</script>
+
+<div use:inView on:enterViewport={handleEnter}>
+  {#if visible}
+    <article
+      class="relative overflow-hidden rounded-[1.9rem] border border-primary-500/15 bg-white/80 p-6 shadow-xl backdrop-blur-xl transition hover:-translate-y-1 hover:shadow-2xl dark:border-surface-700/40 dark:bg-surface-900/80"
+      use:listTransition={index}
+    >
+      <div class="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-primary-500 via-secondary-400 to-primary-500 opacity-70"></div>
+      <div class="flex flex-col gap-6">
+        <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div class="space-y-4">
+            <div class="space-y-2">
+              <h3 class="text-2xl font-semibold text-surface-800 dark:text-surface-50">{song.title}</h3>
+              {#if lastUpdatedLabel}
+                <p class="text-xs uppercase tracking-[0.32em] text-primary-400/80">
+                  {$t('app.updated_label')}: {lastUpdatedLabel}
+                </p>
+              {/if}
+            </div>
+            <div class="flex flex-wrap items-center gap-2 text-xs text-surface-500 dark:text-surface-300">
+              <span class="rounded-full bg-primary-500/10 px-3 py-1 font-semibold uppercase tracking-[0.2em] text-primary-500">
+                {$t('app.page_label')} {song.page}
+              </span>
+              <span class="rounded-full bg-white/80 px-3 py-1 text-surface-500 dark:bg-surface-800/80 dark:text-surface-300">
+                {$t('app.source_label')} {song.source}
+              </span>
+              <span class="rounded-full bg-white/80 px-3 py-1 text-surface-500 dark:bg-surface-800/80 dark:text-surface-300">
+                {$t('app.external_index')} {song.externalIndex}
+              </span>
+            </div>
+          </div>
+          <div class="flex flex-wrap justify-end gap-2 text-sm">
+            <button
+              class={`inline-flex items-center justify-center gap-2 rounded-full border border-primary-500/40 px-5 py-2 font-semibold transition hover:-translate-y-0.5 hover:border-primary-500 hover:bg-primary-500/10 ${
+                isFavourite ? 'bg-primary-500/15 text-primary-600 dark:text-primary-300' : 'text-primary-600 dark:text-primary-200'
+              }`}
+              on:click={() => dispatch('toggleFavourite', `${song.id}-${song.language}`)}
+              type="button"
+            >
+              <Heart class={`h-4 w-4 ${isFavourite ? 'fill-current' : ''}`} />
+              {isFavourite ? $t('app.remove_favourite') : $t('app.add_favourite')}
+            </button>
+            <button
+              class="inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-primary-500 to-secondary-400 px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:shadow-xl"
+              on:click={() => dispatch('open', song)}
+              type="button"
+            >
+              <ExternalLink class="h-4 w-4" />
+              {$t('app.view_song')}
+            </button>
+            {#if remainingItems.length}
+              <button
+                class="inline-flex items-center justify-center gap-2 rounded-full border border-primary-500/25 px-5 py-2 text-sm font-semibold text-surface-600 transition hover:-translate-y-0.5 hover:border-primary-500 hover:text-primary-500 dark:border-surface-700/40 dark:text-surface-200"
+                on:click={() => (expanded = !expanded)}
+                type="button"
+                aria-expanded={expanded}
+              >
+                {#if expanded}
+                  <EyeOff class="h-4 w-4" />
+                  {$t('app.hide_preview')}
+                {:else}
+                  <Eye class="h-4 w-4" />
+                  {$t('app.preview')}
+                {/if}
+              </button>
+            {/if}
+            <button
+              class="inline-flex items-center justify-center gap-2 rounded-full border border-primary-500/25 px-5 py-2 text-sm font-semibold text-surface-600 transition hover:-translate-y-0.5 hover:border-primary-500 hover:text-primary-500 dark:border-surface-700/40 dark:text-surface-200"
+              on:click={copyShareLink}
+              type="button"
+            >
+              <Link2 class="h-4 w-4" />
+              {copyState === 'copied' ? $t('app.copied_link') : $t('app.copy_link')}
+            </button>
+          </div>
+        </div>
+
+        <div class="rounded-2xl border border-primary-500/15 bg-white/70 p-4 text-xs shadow-inner dark:border-surface-700/40 dark:bg-surface-900/70">
+          <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p class="font-semibold uppercase tracking-[0.3em] text-primary-400/80">{$t('app.density_label')}</p>
+              <div class="mt-2 flex items-center gap-3">
+                <span class="relative inline-flex h-2 w-36 overflow-hidden rounded-full bg-primary-500/10">
+                  <span
+                    class="absolute inset-y-0 left-0 origin-left rounded-full bg-gradient-to-r from-primary-500 to-secondary-400"
+                    style:transform={`scaleX(${Math.max(density, 0.05)})`}
+                    style:transition={prefersReducedMotion ? 'none' : 'transform 420ms cubic-bezier(0.22, 1, 0.36, 1)'}
+                  />
+                </span>
+                <span class="text-sm font-semibold text-surface-700 dark:text-surface-200">{densityPercentage}%</span>
+              </div>
+            </div>
+            <p class="text-xs text-surface-500 dark:text-surface-300">
+              {$t('app.density_caption', { values: { chords: chordLines, total: totalLines } })}
+            </p>
+          </div>
+        </div>
+
+        <div class="space-y-3 text-sm leading-relaxed text-surface-700 dark:text-surface-200">
+          {#each previewItems as item}
+            <p
+              class={`whitespace-pre-line ${alignmentClass(item.alignment)} ${item.isBold ? 'font-semibold' : ''} ${item.isItalics ? 'italic' : ''}`}
+            >
+              {#if viewMode === 'chords' && item.type === 'CHORD'}
+                <span class="block text-xs font-semibold uppercase tracking-[0.3em] text-primary-400/80">CHORDS</span>
+                <span class="mt-1 block text-base font-medium">{item.text}</span>
+              {:else}
+                {item.text}
+              {/if}
+            </p>
+          {/each}
+          {#if remainingItems.length && !expanded}
+            <p class="text-xs italic text-surface-500 dark:text-surface-300">
+              {$t('app.preview_remaining', { values: { count: remainingItems.length } })}
+            </p>
+          {/if}
+        </div>
+
+        {#if remainingItems.length && expanded}
+          <div class="space-y-3 text-sm leading-relaxed text-surface-700 dark:text-surface-200" transition:fade>
+            {#each remainingItems as item}
+              <p
+                class={`whitespace-pre-line ${alignmentClass(item.alignment)} ${item.isBold ? 'font-semibold' : ''} ${item.isItalics ? 'italic' : ''}`}
+              >
+                {#if viewMode === 'chords' && item.type === 'CHORD'}
+                  <span class="block text-xs font-semibold uppercase tracking-[0.3em] text-primary-400/80">CHORDS</span>
+                  <span class="mt-1 block text-base font-medium">{item.text}</span>
+                {:else}
+                  {item.text}
+                {/if}
+              </p>
+            {/each}
+          </div>
+        {/if}
+
+        <p class="sr-only" aria-live="polite">
+          {#if copyState === 'copied'}
+            {$t('app.copied_link')}
+          {:else if copyState === 'error'}
+            {$t('app.copy_failed')}
+          {/if}
+        </p>
+      </div>
+    </article>
+  {/if}
+</div>

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -32,6 +32,36 @@
     "external_index": "Index",
     "view_song": "View song",
     "brand_global": "Worldwide worship family",
-    "brand_available_offline": "Offline ready"
+    "brand_available_offline": "Offline ready",
+    "sort": {
+      "label": "Sort by",
+      "page": "Songbook order",
+      "alpha": "A to Z",
+      "recent": "Recently updated",
+      "dense": "Chord rich"
+    },
+    "filters": {
+      "active": "Active filters",
+      "none": "No filters applied",
+      "search": "Search: {query}",
+      "page": "Page {page}",
+      "favourites": "Favourites only"
+    },
+    "density_label": "Chord density",
+    "density_caption": "{chords} of {total} lines use chords",
+    "updated_label": "Updated",
+    "copy_link": "Copy share link",
+    "copied_link": "Link copied!",
+    "copy_failed": "Copy failed",
+    "preview": "Preview lyrics",
+    "hide_preview": "Hide preview",
+    "preview_remaining": "{count} more lines hidden",
+    "search_hint": "Try combining filters and view modes to surface songs faster.",
+    "cta": {
+      "title": "Practice anywhere",
+      "subtitle": "Save sets, practise offline, and stay in sync across teams.",
+      "primary": "Plan a setlist",
+      "secondary": "Learn about the app"
+    }
   }
 }

--- a/src/lib/locales/pl.json
+++ b/src/lib/locales/pl.json
@@ -32,6 +32,36 @@
     "external_index": "Indeks",
     "view_song": "Zobacz pieśń",
     "brand_global": "Globalna rodzina uwielbienia",
-    "brand_available_offline": "Działa offline"
+    "brand_available_offline": "Działa offline",
+    "sort": {
+      "label": "Sortuj według",
+      "page": "Kolejność śpiewnika",
+      "alpha": "A do Z",
+      "recent": "Ostatnio aktualizowane",
+      "dense": "Najwięcej akordów"
+    },
+    "filters": {
+      "active": "Aktywne filtry",
+      "none": "Brak filtrów",
+      "search": "Szukaj: {query}",
+      "page": "Strona {page}",
+      "favourites": "Tylko ulubione"
+    },
+    "density_label": "Gęstość akordów",
+    "density_caption": "Linie z akordami: {chords} / {total}",
+    "updated_label": "Aktualizacja",
+    "copy_link": "Kopiuj link do udostępnienia",
+    "copied_link": "Skopiowano link!",
+    "copy_failed": "Nie udało się skopiować",
+    "preview": "Podgląd tekstu",
+    "hide_preview": "Ukryj podgląd",
+    "preview_remaining": "Ukryto {count} linie",
+    "search_hint": "Łącz filtry i tryby widoku, aby szybciej znaleźć pieśni.",
+    "cta": {
+      "title": "Ćwicz w dowolnym miejscu",
+      "subtitle": "Zapisuj zestawy, ćwicz offline i bądź w kontakcie z zespołem.",
+      "primary": "Zaplanuj setlistę",
+      "secondary": "Dowiedz się więcej"
+    }
   }
 }

--- a/src/lib/utils/lenis.ts
+++ b/src/lib/utils/lenis.ts
@@ -1,0 +1,41 @@
+import { browser } from '$app/environment';
+
+interface LenisController {
+  destroy(): void;
+}
+
+export async function initLenis(): Promise<LenisController | null> {
+  if (!browser) return null;
+
+  const { default: Lenis } = await import('lenis');
+  const lenis = new Lenis({
+    duration: 1.1
+  });
+
+  const root = document.documentElement;
+  const body = document.body;
+
+  body.classList.add('is-lenis');
+  root.dataset.lenis = 'active';
+
+  let rafId: number;
+  const raf = (time: number) => {
+    lenis.raf(time);
+    rafId = requestAnimationFrame(raf);
+  };
+
+  rafId = requestAnimationFrame(raf);
+
+  const resizeObserver = new ResizeObserver(() => lenis.resize());
+  resizeObserver.observe(document.body);
+
+  return {
+    destroy() {
+      cancelAnimationFrame(rafId);
+      resizeObserver.disconnect();
+      body.classList.remove('is-lenis');
+      delete root.dataset.lenis;
+      lenis.destroy();
+    }
+  };
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import '../app.css';
   import { browser } from '$app/environment';
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import { addMessages, init, locale as i18nLocale } from 'svelte-i18n';
   import { get } from 'svelte/store';
   import AppHeader from '$lib/components/layout/AppHeader.svelte';
@@ -21,13 +21,26 @@
     i18nLocale.set(initialLocale);
   }
 
+  let lenisController: { destroy: () => void } | null = null;
+
   onMount(() => {
     loadSongs();
 
     const handleOnline = () => loadSongs(true);
 
+    async function initLenis() {
+      if (!browser) return;
+      const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      if (prefersReducedMotion) return;
+
+      const { initLenis } = await import('$lib/utils/lenis');
+      lenisController = await initLenis();
+    }
+
+    initLenis();
+
     if (browser) {
-      window.addEventListener('online', handleOnline);
+      window.addEventListener('online', handleOnline, { passive: true });
 
       if ('serviceWorker' in navigator) {
         navigator.serviceWorker.register('/service-worker.js');
@@ -40,14 +53,32 @@
       }
     };
   });
+
+  onDestroy(() => {
+    lenisController?.destroy();
+  });
 </script>
 
-<div class="app-shell">
-  <div class="app-shell__inner">
+<div class="relative isolate overflow-hidden">
+  <div
+    class="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_20%_10%,rgba(99,102,241,0.35),transparent_60%),radial-gradient(circle_at_80%_5%,rgba(34,211,238,0.24),transparent_55%),radial-gradient(circle_at_50%_90%,rgba(14,165,233,0.22),transparent_60%)]"
+    aria-hidden="true"
+  ></div>
+  <div class="relative mx-auto flex min-h-screen w-full max-w-[120rem] flex-col px-4 pb-24 sm:px-6 lg:px-12">
     <AppHeader />
-    <main class="app-shell__content">
+    <main class="flex-1 py-10 sm:py-12 lg:py-16">
       <slot />
     </main>
+    <footer class="mt-10 flex flex-col gap-3 py-8 text-sm text-surface-500 dark:text-surface-400">
+      <span class="uppercase tracking-[0.25em] text-xs font-semibold text-primary-400/80">Songbook</span>
+      <p class="max-w-xl leading-relaxed text-surface-600 dark:text-surface-300">
+        Designed for worship leaders and musicians who need an offline-first, international-ready song
+        companion.
+      </p>
+    </footer>
   </div>
-  <div class="app-shell__glow" aria-hidden="true"></div>
+  <div
+    class="pointer-events-none absolute inset-x-1/2 top-[20%] h-[38rem] w-[38rem] -translate-x-1/2 rounded-full bg-primary-500/10 blur-[220px]"
+    aria-hidden="true"
+  ></div>
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,31 +3,55 @@
   import { browser } from '$app/environment';
   import { goto } from '$app/navigation';
   import { language, favourites, viewMode, toggleFavourite } from '$lib/stores/preferences';
-  import { searchableSongs, songs, filterSongs } from '$lib/stores/songStore';
+  import { searchableSongs, songs, filterSongs, type SongSortMode } from '$lib/stores/songStore';
   import { buildPageIndex, songsByPage } from '$lib/utils/pageIndex';
-  import { listTransition } from '$lib/actions/listTransition';
+  import SongCard from '$lib/components/song/SongCard.svelte';
   import { fadeSlide } from '$lib/actions/fadeSlide';
-  import type { Song } from '$lib/types/song';
+  import { inView } from '$lib/actions/inView';
   import { createTabs, melt } from '@melt-ui/svelte';
   import { onMount } from 'svelte';
-  import { Search, ChevronDown, ChevronUp, Dot, Heart, Music3, BookText } from 'lucide-svelte';
   import { get } from 'svelte/store';
+  import {
+    Search,
+    Filter,
+    Heart,
+    LayoutList,
+    Sparkles,
+    ChevronDown,
+    ChevronUp,
+    MapPinned,
+    ArrowDownAZ,
+    Clock3,
+    BarChart3
+  } from 'lucide-svelte';
+  import type { Song } from '$lib/types/song';
 
   let query = '';
   let menuView: 'index' | 'favourites' = 'index';
   let pageFilter: number | null = null;
   let filtersOpen = browser ? false : true;
   let isDesktop = false;
+  let statsVisible = false;
+  let activeViewMode: 'basic' | 'chords' = 'basic';
+  let sortMode: SongSortMode = 'page';
+  let searchRef: HTMLInputElement | null = null;
+
+  const sortOptions: { value: SongSortMode; label: string; icon: typeof MapPinned }[] = [
+    { value: 'page', label: 'app.sort.page', icon: MapPinned },
+    { value: 'alpha', label: 'app.sort.alpha', icon: ArrowDownAZ },
+    { value: 'recent', label: 'app.sort.recent', icon: Clock3 },
+    { value: 'dense', label: 'app.sort.dense', icon: BarChart3 }
+  ];
 
   onMount(() => {
     if (!browser) return;
     const update = () => {
-      const desktop = window.innerWidth >= 1280;
+      const desktop = window.innerWidth >= 1200;
       isDesktop = desktop;
       filtersOpen = desktop;
     };
     update();
-    window.addEventListener('resize', update);
+    window.addEventListener('resize', update, { passive: true });
     return () => window.removeEventListener('resize', update);
   });
 
@@ -42,6 +66,7 @@
   $: if ($viewTabValue && $viewTabValue !== $viewMode) {
     viewMode.set($viewTabValue as 'basic' | 'chords');
   }
+  $: activeViewMode = (($viewTabValue as 'basic' | 'chords') ?? 'basic');
 
   $: availableSongs = $songs.filter((song) => song.language === $language);
   $: groupedByPage = songsByPage(availableSongs);
@@ -52,17 +77,23 @@
     $language,
     menuView === 'favourites',
     $favourites,
-    pageFilter
+    pageFilter,
+    sortMode
   );
   $: favouriteSongs = $favourites
     .map((key) => $songs.find((song) => `${song.id}-${song.language}` === key) ?? null)
     .filter((song): song is Song => song !== null);
+  $: filterBadges = [
+    query ? $t('app.filters.search', { values: { query } }) : null,
+    menuView === 'favourites' ? $t('app.filters.favourites') : null,
+    pageFilter ? $t('app.filters.page', { values: { page: pageFilter } }) : null
+  ].filter((badge): badge is string => Boolean(badge));
 
   function handleClearFilters() {
     query = '';
     pageFilter = null;
     menuView = 'index';
-    filtersOpen = false;
+    filtersOpen = isDesktop;
   }
 
   function openSong(song: Song) {
@@ -73,86 +104,111 @@
     pageFilter = pageNumber;
     menuView = 'index';
   }
+
+  function focusSearchInput() {
+    if (!browser) return;
+    filtersOpen = true;
+    menuView = 'index';
+    searchRef?.focus();
+    searchRef?.select();
+  }
+
+  function openFavouritesQuickly() {
+    filtersOpen = true;
+    menuView = 'favourites';
+    if (!browser) return;
+    document.getElementById('songbook-filters')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
 </script>
 
-<section class="space-y-12">
-  <div class="card px-6 py-6 sm:px-8 sm:py-10" use:fadeSlide={{ delay: 0.05 }}>
-    <div class="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
-      <div class="space-y-4">
-        <div class="inline-flex items-center gap-2 rounded-full bg-[rgb(var(--surface-muted))]/70 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">
-          <Music3 class="h-4 w-4" />
+<section class="space-y-16 pb-12">
+  <div class="relative overflow-hidden rounded-[2.5rem] border border-primary-500/20 bg-white/80 px-6 py-8 shadow-2xl backdrop-blur-xl dark:border-surface-700/40 dark:bg-surface-900/80 sm:px-10" use:fadeSlide>
+    <div class="pointer-events-none absolute inset-0 -z-10">
+      <div class="absolute -left-10 top-0 h-64 w-64 rounded-full bg-primary-500/15 blur-[120px]"></div>
+      <div class="absolute bottom-0 right-0 h-52 w-52 rounded-full bg-secondary-400/20 blur-[110px]"></div>
+    </div>
+    <div class="flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between">
+      <div class="space-y-6">
+        <div class="inline-flex items-center gap-2 rounded-full bg-primary-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-primary-500">
+          <Sparkles class="h-4 w-4" />
           <span>{$t('app.search_placeholder')}</span>
         </div>
-        <h2 class="text-2xl font-semibold text-[rgb(var(--foreground))] sm:text-3xl">
-          {$t('app.toggle_index')}
-        </h2>
-        <p class="max-w-2xl text-sm text-[rgb(var(--muted))] sm:text-base">
-          {$t('app.tagline')}
-        </p>
+        <div class="space-y-3">
+          <h2 class="text-balance text-3xl font-semibold sm:text-4xl">
+            {$t('app.toggle_index')}
+          </h2>
+          <p class="max-w-2xl text-base text-surface-600 dark:text-surface-300">
+            {$t('app.tagline')}
+          </p>
+        </div>
       </div>
       <div class="w-full max-w-xl space-y-3">
-        <label class="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]" for="song-search">
+        <label class="text-xs font-semibold uppercase tracking-[0.28em] text-surface-500 dark:text-surface-400" for="song-search">
           {$t('app.search_placeholder')}
         </label>
-        <div class="flex items-center gap-3 rounded-2xl border border-[rgb(var(--surface-border))/0.6] bg-white/65 px-4 py-3 shadow-inner dark:bg-white/10">
-          <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-[rgb(var(--surface-muted))]/70 text-[rgb(var(--accent))]">
+        <div class="flex items-center gap-3 rounded-[1.75rem] border border-primary-500/20 bg-white/90 px-4 py-3 shadow-inner dark:border-surface-700/40 dark:bg-surface-800/80">
+          <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-primary-500/10 text-primary-500">
             <Search class="h-5 w-5" />
           </span>
           <input
             id="song-search"
-            class="w-full bg-transparent text-base text-[rgb(var(--foreground))] outline-none"
+            class="w-full bg-transparent text-base text-surface-700 outline-none placeholder:text-surface-400 dark:text-surface-100"
             type="search"
             placeholder={$t('app.search_placeholder')}
             bind:value={query}
+            bind:this={searchRef}
           />
           {#if query}
             <button
-              class="text-sm font-semibold text-[rgb(var(--accent))] transition hover:text-[rgb(var(--accent))]/80"
+              class="text-xs font-semibold uppercase tracking-[0.28em] text-primary-500 transition hover:text-primary-400"
               on:click={() => (query = '')}
+              type="button"
             >
               {$t('app.clear_query')}
             </button>
           {/if}
         </div>
+        <p class="text-xs text-surface-500 dark:text-surface-300">{$t('app.search_hint')}</p>
       </div>
     </div>
-    <div class="mt-8 grid gap-4 sm:grid-cols-3" use:fadeSlide={{ delay: 0.1 }}>
-      <div class="stat">
-        <Dot class="h-5 w-5 text-[rgb(var(--accent))]" />
-        <div>
-          <p class="text-xs uppercase tracking-wide text-[rgb(var(--muted))]">{$t('app.page_index')}</p>
-          <p class="text-lg font-semibold text-[rgb(var(--foreground))]">{filteredSongs.length} / {availableSongs.length}</p>
-        </div>
+    <div class="mt-10 grid gap-4 md:grid-cols-3" use:inView on:enterViewport={() => (statsVisible = true)}>
+      <div class="rounded-3xl border border-primary-500/15 bg-white/75 p-5 shadow-lg transition-all duration-500 dark:border-surface-700/40 dark:bg-surface-900/80" class:opacity-0={!statsVisible} class:translate-y-4={!statsVisible} class:opacity-100={statsVisible} class:translate-y-0={statsVisible}>
+        <p class="text-xs font-semibold uppercase tracking-[0.32em] text-primary-400/80">
+          {$t('app.page_index')}
+        </p>
+        <p class="mt-2 text-2xl font-semibold text-surface-800 dark:text-surface-100">{filteredSongs.length} / {availableSongs.length}</p>
       </div>
-      <div class="stat">
-        <Heart class="h-5 w-5 text-[rgb(var(--accent))]" />
-        <div>
-          <p class="text-xs uppercase tracking-wide text-[rgb(var(--muted))]">{$t('app.toggle_favourites')}</p>
-          <p class="text-lg font-semibold text-[rgb(var(--foreground))]">{favouriteSongs.length}</p>
-        </div>
+      <div class="rounded-3xl border border-primary-500/15 bg-white/75 p-5 shadow-lg transition-all duration-500 dark:border-surface-700/40 dark:bg-surface-900/80" class:opacity-0={!statsVisible} class:translate-y-4={!statsVisible} class:opacity-100={statsVisible} class:translate-y-0={statsVisible}>
+        <p class="text-xs font-semibold uppercase tracking-[0.32em] text-primary-400/80">
+          {$t('app.toggle_favourites')}
+        </p>
+        <p class="mt-2 text-2xl font-semibold text-surface-800 dark:text-surface-100">{favouriteSongs.length}</p>
       </div>
-      <div class="stat">
-        <BookText class="h-5 w-5 text-[rgb(var(--accent))]" />
-        <div>
-          <p class="text-xs uppercase tracking-wide text-[rgb(var(--muted))]">{$t('app.view_song')}</p>
-          <p class="text-lg font-semibold text-[rgb(var(--foreground))]">
-            {$viewMode === 'basic' ? $t('app.view.basic') : $t('app.view.chords')}
-          </p>
-        </div>
+      <div class="rounded-3xl border border-primary-500/15 bg-white/75 p-5 shadow-lg transition-all duration-500 dark:border-surface-700/40 dark:bg-surface-900/80" class:opacity-0={!statsVisible} class:translate-y-4={!statsVisible} class:opacity-100={statsVisible} class:translate-y-0={statsVisible}>
+        <p class="text-xs font-semibold uppercase tracking-[0.32em] text-primary-400/80">
+          {$t('app.view_song')}
+        </p>
+        <p class="mt-2 text-2xl font-semibold text-surface-800 dark:text-surface-100">
+          {$viewMode === 'basic' ? $t('app.view.basic') : $t('app.view.chords')}
+        </p>
       </div>
     </div>
   </div>
 
-  <div class="grid gap-10 xl:grid-cols-[320px,1fr]">
-    <div class="space-y-4 xl:space-y-6">
+  <div class="grid gap-12 lg:grid-cols-[320px,1fr]">
+    <aside class="space-y-4 lg:space-y-6" use:fadeSlide={{ axis: 'y', from: 30 }}>
       <button
-        class="toolbar flex w-full items-center justify-between rounded-full px-4 py-3 text-sm font-semibold text-[rgb(var(--foreground))] transition hover:shadow-lg xl:hidden"
+        class="flex w-full items-center justify-between rounded-full border border-primary-500/20 bg-white/80 px-5 py-3 text-sm font-semibold text-surface-700 transition hover:shadow-lg dark:border-surface-700/40 dark:bg-surface-900/80 dark:text-surface-100 lg:hidden"
         on:click={() => (filtersOpen = !filtersOpen)}
         aria-expanded={filtersOpen}
         aria-controls="songbook-filters"
+        type="button"
       >
-        <span>{$t('app.page_index')}</span>
-        <span class="inline-flex h-7 w-7 items-center justify-center rounded-full bg-[rgb(var(--surface-muted))]/80 text-[rgb(var(--muted))]">
+        <span class="inline-flex items-center gap-2">
+          <Filter class="h-4 w-4" />
+          {$t('app.page_index')}
+        </span>
+        <span class="inline-flex h-7 w-7 items-center justify-center rounded-full bg-primary-500/10 text-primary-500">
           {#if filtersOpen}
             <ChevronUp class="h-4 w-4" />
           {:else}
@@ -161,46 +217,78 @@
         </span>
       </button>
 
-      <aside
+      <div
         id="songbook-filters"
-        class="card card-muted space-y-6 px-6 py-6"
+        class="space-y-6 rounded-[2rem] border border-primary-500/20 bg-white/80 p-6 shadow-xl backdrop-blur-xl dark:border-surface-700/40 dark:bg-surface-900/80"
         class:hidden={!filtersOpen && !isDesktop}
       >
         <div class="flex items-center justify-between">
-          <h3 class="text-lg font-semibold text-[rgb(var(--foreground))]">{$t('app.page_index')}</h3>
+          <h3 class="text-lg font-semibold text-surface-800 dark:text-surface-50">{$t('app.page_index')}</h3>
           <button
-            class="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--accent))] hover:underline"
+            class="text-xs font-semibold uppercase tracking-[0.3em] text-primary-500 transition hover:text-primary-400"
             on:click={handleClearFilters}
+            type="button"
           >
             {$t('app.reset_filters')}
           </button>
         </div>
-        <div class="grid gap-2 sm:grid-cols-2 xl:grid-cols-1">
+
+        <div class="rounded-2xl border border-primary-500/15 bg-white/65 p-4 shadow-inner dark:border-surface-700/40 dark:bg-surface-800/70">
+          <p class="text-xs font-semibold uppercase tracking-[0.28em] text-primary-400/80">
+            {$t('app.filters.active')}
+          </p>
+          {#if filterBadges.length}
+            <div class="mt-3 flex flex-wrap gap-2">
+              {#each filterBadges as badge}
+                <span class="inline-flex items-center gap-2 rounded-full bg-primary-500/10 px-3 py-1 text-xs font-semibold text-primary-500">
+                  {badge}
+                </span>
+              {/each}
+            </div>
+          {:else}
+            <p class="mt-3 text-xs text-surface-500 dark:text-surface-300">{$t('app.filters.none')}</p>
+          {/if}
+        </div>
+
+        <div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-1">
           <button
-            class={`btn ${menuView === 'index' ? 'btn-primary' : 'btn-ghost'}`}
+            class={`inline-flex items-center justify-center gap-2 rounded-full px-5 py-2 text-sm font-semibold transition ${
+              menuView === 'index'
+                ? 'bg-gradient-to-r from-primary-500 to-secondary-400 text-white shadow-lg'
+                : 'border border-primary-500/25 bg-white/70 text-surface-600 dark:border-surface-700/40 dark:bg-surface-800/60 dark:text-surface-200'
+            }`}
             on:click={() => (menuView = 'index')}
+            type="button"
           >
+            <LayoutList class="h-4 w-4" />
             {$t('app.toggle_index')}
           </button>
           <button
-            class={`btn ${menuView === 'favourites' ? 'btn-primary' : 'btn-ghost'}`}
+            class={`inline-flex items-center justify-center gap-2 rounded-full px-5 py-2 text-sm font-semibold transition ${
+              menuView === 'favourites'
+                ? 'bg-gradient-to-r from-primary-500 to-secondary-400 text-white shadow-lg'
+                : 'border border-primary-500/25 bg-white/70 text-surface-600 dark:border-surface-700/40 dark:bg-surface-800/60 dark:text-surface-200'
+            }`}
             on:click={() => (menuView = 'favourites')}
+            type="button"
           >
+            <Heart class="h-4 w-4" />
             {$t('app.toggle_favourites')}
           </button>
         </div>
+
         {#if menuView === 'favourites'}
           {#if favouriteSongs.length === 0}
-            <p class="rounded-2xl bg-white/60 px-4 py-3 text-sm text-[rgb(var(--muted))] dark:bg-white/10">
+            <p class="rounded-2xl border border-primary-500/15 bg-white/60 p-4 text-sm text-surface-500 dark:border-surface-700/30 dark:bg-surface-800/70 dark:text-surface-300">
               {$t('app.no_favourites')}
             </p>
           {:else}
             <ul class="space-y-3 text-sm">
               {#each favouriteSongs as favSong (favSong.id + '-' + favSong.language)}
-                <li class="card-outline rounded-2xl bg-white/70 p-4 shadow-sm transition hover:shadow-lg dark:bg-white/5">
-                  <button class="w-full text-left" on:click={() => openSong(favSong)}>
-                    <p class="text-base font-semibold text-[rgb(var(--foreground))]">{favSong.title}</p>
-                    <p class="text-xs text-[rgb(var(--muted))]">
+                <li class="overflow-hidden rounded-2xl border border-primary-500/15 bg-white/70 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg dark:border-surface-700/40 dark:bg-surface-800/70">
+                  <button class="flex w-full flex-col items-start gap-1 px-4 py-3 text-left" on:click={() => openSong(favSong)} type="button">
+                    <p class="text-base font-semibold text-surface-800 dark:text-surface-100">{favSong.title}</p>
+                    <p class="text-xs uppercase tracking-[0.3em] text-primary-400/80">
                       {$t('app.page_label')} {favSong.page}
                     </p>
                   </button>
@@ -211,22 +299,27 @@
         {:else}
           <div class="space-y-4">
             {#each pageGroups as group}
-              <details class="card-outline overflow-hidden rounded-2xl bg-white/60 dark:bg-white/5" open>
-                <summary class="flex cursor-pointer items-center justify-between px-4 py-3 text-sm font-semibold text-[rgb(var(--foreground))]">
-                  <span>{group.label}</span>
-                  <span class="chip">{group.pages.length}</span>
+              <details class="overflow-hidden rounded-2xl border border-primary-500/15 bg-white/70 p-0 dark:border-surface-700/40 dark:bg-surface-800/70" open>
+                <summary class="flex cursor-pointer items-center justify-between px-5 py-3 text-sm font-semibold text-surface-700 dark:text-surface-200">
+                  <span class="inline-flex items-center gap-2">
+                    <MapPinned class="h-4 w-4 text-primary-500" />
+                    {group.label}
+                  </span>
+                  <span class="rounded-full bg-primary-500/10 px-3 py-1 text-xs font-semibold text-primary-500">
+                    {group.pages.length}
+                  </span>
                 </summary>
-                <div class="divide-y divide-[rgb(var(--surface-border))/0.6]">
+                <div class="divide-y divide-primary-500/10">
                   {#each group.pages as pageNumber}
                     <button
-                      class={`flex w-full items-center justify-between px-4 py-2 text-left text-sm transition ${
-                        pageFilter === pageNumber
-                          ? 'text-[rgb(var(--accent))]' : 'hover:text-[rgb(var(--accent))]'
+                      class={`flex w-full items-center justify-between px-5 py-2 text-left text-sm transition ${
+                        pageFilter === pageNumber ? 'text-primary-500' : 'hover:text-primary-500'
                       }`}
                       on:click={() => handlePageSelect(pageNumber)}
+                      type="button"
                     >
                       <span>{$t('app.page_label')} {pageNumber}</span>
-                      <span class="text-xs text-[rgb(var(--muted))]">
+                      <span class="text-xs text-surface-500 dark:text-surface-300">
                         {(groupedByPage[pageNumber] ?? []).length}
                       </span>
                     </button>
@@ -236,102 +329,138 @@
             {/each}
           </div>
         {/if}
-      </aside>
-    </div>
+      </div>
+    </aside>
 
-    <section class="space-y-6">
-      <div class="toolbar flex flex-wrap items-center justify-between gap-4 rounded-3xl px-4 py-3" use:melt={$viewTabsRoot}>
-        <div class="flex items-center gap-3 text-sm text-[rgb(var(--muted))]">
-          <span class="font-semibold text-[rgb(var(--foreground))]">{filteredSongs.length}</span>
-          <span>/</span>
-          <span>{availableSongs.length}</span>
-          {#if pageFilter}
-            <span class="chip">{$t('app.page_label')} {pageFilter}</span>
+    <section class="space-y-6" use:fadeSlide={{ axis: 'y', from: 30, delay: 0.05 }}>
+      <div class="space-y-4 rounded-3xl border border-primary-500/20 bg-white/80 px-5 py-5 text-sm shadow-lg backdrop-blur-xl dark:border-surface-700/40 dark:bg-surface-900/80" use:melt={$viewTabsRoot}>
+        <div class="flex flex-wrap items-center justify-between gap-4 text-surface-500 dark:text-surface-300">
+          <div class="flex items-center gap-3">
+            <span class="text-lg font-semibold text-surface-800 dark:text-surface-100">{filteredSongs.length}</span>
+            <span>/</span>
+            <span>{availableSongs.length}</span>
+            {#if pageFilter}
+              <span class="rounded-full bg-primary-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-primary-500">
+                {$t('app.page_label')} {pageFilter}
+              </span>
+            {/if}
+          </div>
+          {#if filterBadges.length}
+            <div class="flex flex-wrap items-center gap-2">
+              {#each filterBadges.slice(0, 2) as badge, badgeIndex}
+                <span class="rounded-full bg-primary-500/10 px-3 py-1 text-xs font-semibold text-primary-500">{badge}</span>
+                {#if badgeIndex === 1 && filterBadges.length > 2}
+                  <span class="rounded-full bg-white/70 px-3 py-1 text-xs font-semibold text-surface-500 dark:bg-surface-800/70 dark:text-surface-200">
+                    +{filterBadges.length - 2}
+                  </span>
+                {/if}
+              {/each}
+            </div>
           {/if}
         </div>
-        <div class="flex gap-2" use:melt={$viewTabsList}>
-          <button
-            class={`btn ${$viewTabValue === 'basic' ? 'btn-primary' : 'btn-ghost'}`}
-            use:melt={$viewTabsTrigger({ value: 'basic' })}
-          >
-            {$t('app.view.basic')}
-          </button>
-          <button
-            class={`btn ${$viewTabValue === 'chords' ? 'btn-primary' : 'btn-ghost'}`}
-            use:melt={$viewTabsTrigger({ value: 'chords' })}
-          >
-            {$t('app.view.chords')}
-          </button>
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <div class="flex flex-wrap gap-2" use:melt={$viewTabsList}>
+            <button
+              class={`inline-flex items-center justify-center gap-2 rounded-full px-5 py-2 text-sm font-semibold transition ${
+                $viewTabValue === 'basic'
+                  ? 'bg-gradient-to-r from-primary-500 to-secondary-400 text-white shadow-lg'
+                  : 'border border-primary-500/20 bg-white/70 text-surface-600 dark:border-surface-700/40 dark:bg-surface-800/70 dark:text-surface-200'
+              }`}
+              use:melt={$viewTabsTrigger({ value: 'basic' })}
+              type="button"
+            >
+              {$t('app.view.basic')}
+            </button>
+            <button
+              class={`inline-flex items-center justify-center gap-2 rounded-full px-5 py-2 text-sm font-semibold transition ${
+                $viewTabValue === 'chords'
+                  ? 'bg-gradient-to-r from-primary-500 to-secondary-400 text-white shadow-lg'
+                  : 'border border-primary-500/20 bg-white/70 text-surface-600 dark:border-surface-700/40 dark:bg-surface-800/70 dark:text-surface-200'
+              }`}
+              use:melt={$viewTabsTrigger({ value: 'chords' })}
+              type="button"
+            >
+              {$t('app.view.chords')}
+            </button>
+          </div>
+          <div class="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-surface-500 dark:text-surface-300">
+            <span>{$t('app.sort.label')}</span>
+            {#each sortOptions as option}
+              <button
+                class={`inline-flex items-center justify-center gap-2 rounded-full px-4 py-2 text-[11px] font-semibold normal-case tracking-normal transition ${
+                  sortMode === option.value
+                    ? 'bg-gradient-to-r from-primary-500 to-secondary-400 text-white shadow-lg'
+                    : 'border border-primary-500/20 bg-white/70 text-surface-600 dark:border-surface-700/40 dark:bg-surface-800/70 dark:text-surface-200'
+                }`}
+                aria-pressed={sortMode === option.value}
+                on:click={() => (sortMode = option.value)}
+                type="button"
+              >
+                <span class="inline-flex items-center gap-2 text-sm">
+                  <svelte:component this={option.icon} class="h-4 w-4" />
+                  <span>{$t(option.label)}</span>
+                </span>
+              </button>
+            {/each}
+          </div>
         </div>
       </div>
 
       {#if filteredSongs.length === 0}
-        <div class="card-muted rounded-3xl px-8 py-12 text-center text-sm text-[rgb(var(--muted))]">
+        <div class="rounded-[2rem] border border-primary-500/15 bg-white/70 px-8 py-12 text-center text-sm text-surface-500 shadow-inner dark:border-surface-700/40 dark:bg-surface-900/80 dark:text-surface-300">
           {$t('app.empty_state')}
         </div>
       {:else}
-        <div class="grid gap-6">
+        <div class="space-y-6">
           {#each filteredSongs as song, index (song.id + '-' + song.language)}
-            <article
-              class="card relative overflow-hidden px-6 py-6 transition hover:-translate-y-1 hover:shadow-2xl sm:px-8"
-              use:listTransition={index}
-            >
-              <div class="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-[rgb(var(--accent))] via-[rgb(var(--secondary))] to-[rgb(var(--accent))] opacity-75"></div>
-              <div class="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
-                <div class="space-y-3">
-                  <h3 class="text-2xl font-semibold text-[rgb(var(--foreground))]">{song.title}</h3>
-                  <div class="flex flex-wrap items-center gap-2 text-xs text-[rgb(var(--muted))]">
-                    <span class="chip">{$t('app.page_label')} {song.page}</span>
-                    <span class="chip">{$t('app.source_label')} {song.source}</span>
-                    <span class="chip">{$t('app.external_index')} {song.externalIndex}</span>
-                  </div>
-                </div>
-                <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
-                  <button
-                    class={`btn ${$favourites.includes(`${song.id}-${song.language}`) ? 'btn-primary' : 'btn-ghost'}`}
-                    on:click={() => toggleFavourite(`${song.id}-${song.language}`)}
-                  >
-                    {$favourites.includes(`${song.id}-${song.language}`)
-                      ? $t('app.remove_favourite')
-                      : $t('app.add_favourite')}
-                  </button>
-                  <button
-                    class="btn btn-primary"
-                    on:click={() => openSong(song)}
-                  >
-                    {$t('app.view_song')}
-                  </button>
-                </div>
-              </div>
-
-              <div class={`mt-6 space-y-2 text-[rgb(var(--foreground))] ${
-                $viewTabValue === 'chords' ? 'lg:grid lg:grid-cols-[200px,1fr] lg:gap-4' : ''
-              }`}>
-                {#each song.items as item}
-                  {#if item.text.trim().length}
-                    <p
-                      class={`text-sm leading-relaxed ${
-                        item.alignment === 'CENTER'
-                          ? 'text-center'
-                          : item.alignment === 'RIGHT'
-                          ? 'text-right'
-                          : 'text-left'
-                      } ${item.isBold ? 'font-semibold' : ''} ${item.isItalics ? 'italic' : ''}`}
-                    >
-                      {#if $viewTabValue === 'chords'}
-                        <span class="text-xs uppercase tracking-wide text-[rgb(var(--muted))]">TAB</span>
-                        <span class="ml-3 block text-base font-medium">{item.text}</span>
-                      {:else}
-                        {item.text}
-                      {/if}
-                    </p>
-                  {/if}
-                {/each}
-              </div>
-            </article>
+            <SongCard
+              {song}
+              {index}
+              viewMode={activeViewMode}
+              isFavourite={$favourites.includes(`${song.id}-${song.language}`)}
+              on:open={(event) => openSong(event.detail)}
+              on:toggleFavourite={(event) => toggleFavourite(event.detail)}
+            />
           {/each}
         </div>
       {/if}
     </section>
+  </div>
+</section>
+
+<section class="relative mt-16 overflow-hidden rounded-[2.75rem] border border-primary-500/20 bg-gradient-to-br from-primary-500/10 via-white/80 to-secondary-400/10 px-6 py-12 shadow-2xl backdrop-blur-xl dark:border-surface-700/40 dark:from-primary-500/15 dark:via-surface-900/90 dark:to-secondary-500/10 sm:px-12" use:fadeSlide={{ axis: 'y', from: 40, delay: 0.08 }}>
+  <div class="pointer-events-none absolute inset-0 -z-10">
+    <div class="absolute -left-24 top-0 h-64 w-64 rounded-full bg-primary-500/20 blur-[140px]"></div>
+    <div class="absolute bottom-0 right-0 h-72 w-72 rounded-full bg-secondary-400/25 blur-[160px]"></div>
+  </div>
+  <div class="mx-auto flex max-w-3xl flex-col items-center gap-6 text-center">
+    <span class="inline-flex items-center gap-2 rounded-full bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.32em] text-primary-500 dark:bg-surface-800/80">
+      <Sparkles class="h-4 w-4" />
+      {$t('app.brand_global')}
+    </span>
+    <h3 class="text-balance text-3xl font-semibold text-surface-900 dark:text-surface-50 sm:text-4xl">
+      {$t('app.cta.title')}
+    </h3>
+    <p class="max-w-2xl text-base text-surface-600 dark:text-surface-300">
+      {$t('app.cta.subtitle')}
+    </p>
+    <div class="flex flex-wrap justify-center gap-3">
+      <button
+        class="inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-primary-500 to-secondary-400 px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:shadow-xl"
+        on:click={focusSearchInput}
+        type="button"
+      >
+        <LayoutList class="h-4 w-4" />
+        {$t('app.cta.primary')}
+      </button>
+      <button
+        class="inline-flex items-center justify-center gap-2 rounded-full border border-primary-500/25 bg-white/80 px-6 py-3 text-sm font-semibold text-surface-600 transition hover:-translate-y-0.5 hover:border-primary-500 hover:text-primary-500 dark:border-surface-700/40 dark:bg-surface-900/80 dark:text-surface-200"
+        on:click={openFavouritesQuickly}
+        type="button"
+      >
+        <Heart class="h-4 w-4" />
+        {$t('app.cta.secondary')}
+      </button>
+    </div>
   </div>
 </section>

--- a/src/types/lenis.d.ts
+++ b/src/types/lenis.d.ts
@@ -1,0 +1,17 @@
+declare module 'lenis' {
+  interface LenisOptions {
+    duration?: number;
+    easing?: (t: number) => number;
+    smoothWheel?: boolean;
+    smoothTouch?: boolean;
+  }
+
+  export default class Lenis {
+    constructor(options?: LenisOptions);
+    raf(time: number): void;
+    stop(): void;
+    start(): void;
+    resize(): void;
+    destroy(): void;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+import skeleton from '@skeletonlabs/tw-plugin';
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./src/**/*.{html,js,svelte,ts}'],
@@ -17,8 +19,68 @@ export default {
         '7xl': ['4.5rem', { lineHeight: '1' }],
         '8xl': ['6rem', { lineHeight: '1' }],
         '9xl': ['8rem', { lineHeight: '1' }]
+      },
+      boxShadow: {
+        glow: '0 40px 160px -60px rgba(99, 102, 241, 0.45)'
       }
     }
   },
-  plugins: []
+  plugins: [
+    skeleton({
+      themes: {
+        preset: ['skeleton', 'modern'],
+        custom: [
+          {
+            name: 'songbook-modern',
+            properties: {
+              '--theme-font-family-base': 'Inter, "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+              '--theme-font-family-heading': 'Inter, "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+              '--theme-font-color-base': '14 23 42',
+              '--theme-font-color-dark': '237 242 255',
+              '--theme-rounded-base': '1.75rem',
+              '--theme-rounded-container': '2rem',
+              '--theme-border-base': '1px',
+              '--on-primary': '244 246 255',
+              '--on-secondary': '12 17 32',
+              '--on-tertiary': '12 17 32',
+              '--on-success': '12 17 32',
+              '--on-warning': '12 17 32',
+              '--on-error': '244 246 255',
+              '--on-surface': '14 23 42',
+              '--color-primary-50': '238 242 255',
+              '--color-primary-100': '224 231 255',
+              '--color-primary-200': '199 210 254',
+              '--color-primary-300': '165 180 252',
+              '--color-primary-400': '129 140 248',
+              '--color-primary-500': '99 102 241',
+              '--color-primary-600': '79 70 229',
+              '--color-primary-700': '67 56 202',
+              '--color-primary-800': '55 48 163',
+              '--color-primary-900': '49 46 129',
+              '--color-secondary-50': '236 254 255',
+              '--color-secondary-100': '207 250 254',
+              '--color-secondary-200': '165 243 252',
+              '--color-secondary-300': '103 232 249',
+              '--color-secondary-400': '34 211 238',
+              '--color-secondary-500': '14 165 233',
+              '--color-secondary-600': '8 145 178',
+              '--color-secondary-700': '14 116 144',
+              '--color-secondary-800': '21 94 117',
+              '--color-secondary-900': '22 78 99',
+              '--color-surface-50': '244 247 255',
+              '--color-surface-100': '235 240 255',
+              '--color-surface-200': '221 229 254',
+              '--color-surface-300': '196 210 252',
+              '--color-surface-400': '165 180 252',
+              '--color-surface-500': '129 140 248',
+              '--color-surface-600': '99 102 241',
+              '--color-surface-700': '79 70 229',
+              '--color-surface-800': '67 56 202',
+              '--color-surface-900': '55 48 163'
+            }
+          }
+        ]
+      }
+    })
+  ]
 };


### PR DESCRIPTION
## Summary
- add adaptive sorting controls, filter badges, and a guided CTA to the song index page
- refresh song cards with expandable previews, chord-density insights, and shareable links
- extend locale strings and lenis typings to support the new interface text and behaviors

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d985871ea8832794b8f3819a944334