### PR TITLE
Exclude problematic dependencies from Vite optimizer

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,18 @@ import devtoolsJson from 'vite-plugin-devtools-json';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
+const optimizeDepsExclude = [
+        'svelte-i18n',
+        '@melt-ui/svelte',
+        'lucide-svelte',
+        'idb',
+        'motion',
+        '@supabase/supabase-js'
+];
+
 export default defineConfig({
-        plugins: [sveltekit(), devtoolsJson()]
+        plugins: [sveltekit(), devtoolsJson()],
+        optimizeDeps: {
+                exclude: optimizeDepsExclude
+        }
 });


### PR DESCRIPTION
## Summary
- add an explicit `optimizeDeps.exclude` list for dependencies that fail when pre-optimized by Vite
- keep existing plugin configuration intact while ensuring the dev server no longer references missing files

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68d9aaaaaef4832780f2346d29dece08