### PR TITLE
Revamp hero layout and simplify preferences

### DIFF
--- a/src/lib/components/layout/AppHeader.svelte
+++ b/src/lib/components/layout/AppHeader.svelte
@@ -1,183 +1,74 @@
 <script lang="ts">
-  import { onDestroy, onMount } from 'svelte';
-  import { derived } from 'svelte/store';
   import { t } from 'svelte-i18n';
-  import { fadeSlide } from '$lib/actions/fadeSlide';
-  import { language, theme } from '$lib/stores/preferences';
+  import { language } from '$lib/stores/preferences';
   import { isSyncing, lastSynced } from '$lib/stores/songStore';
-  import { animate } from 'motion';
-  import { Languages, Music3, Orbit, Sparkles, Sun, MoonStar } from 'lucide-svelte';
+  import { derived } from 'svelte/store';
+  import { Languages, Search } from 'lucide-svelte';
 
-  const syncingLabel = derived([isSyncing, lastSynced], ([$isSyncing, $lastSynced]) => {
-    if ($isSyncing) return $t('app.syncing');
-    if ($lastSynced) return `${$t('app.last_synced')}: ${new Date($lastSynced).toLocaleString()}`;
-    return '';
-  });
-
-  let prefersReducedMotion = true;
-  let orbRef: HTMLDivElement | null = null;
-
-  let stopOrbAnimation: (() => void) | null = null;
-
-  onMount(() => {
-    prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    if (prefersReducedMotion || !orbRef) return;
-    orbRef.style.willChange = 'transform, opacity';
-    const animation = animate(
-      orbRef,
-      { opacity: [0.28, 0.5, 0.28], transform: ['translate3d(0, -10px, 0)', 'translate3d(0, 6px, 0)', 'translate3d(0, -10px, 0)'] },
-      { duration: 9, easing: [0.33, 1, 0.68, 1], repeat: Infinity }
-    );
-    stopOrbAnimation = () => {
-      animation.cancel();
-      orbRef?.style.removeProperty('will-change');
-    };
-  });
-
-  onDestroy(() => {
-    stopOrbAnimation?.();
-  });
-
-  // const highlightCards = [
-  //   {
-  //     icon: Music3,
-  //     label: 'app.brand_available_offline',
-  //     description: 'app.toggle_index'
-  //   },
-  //   {
-  //     icon: Sun,
-  //     label: 'app.theme_label',
-  //     description: 'app.system'
-  //   },
-  //   {
-  //     icon: Orbit,
-  //     label: 'app.view_song',
-  //     description: 'app.tagline'
-  //   }
-  // ];
+  const syncStatus = derived(isSyncing, ($isSyncing) => ($isSyncing ? $t('app.syncing') : $t('app.brand_available_offline')));
 </script>
 
-<section class="relative pt-12 sm:pt-16 lg:pt-20">
-  <div class="absolute inset-0 -z-10">
-    <div class="pointer-events-none absolute inset-x-10 top-0 h-64 rounded-[50%] bg-primary-500/20 blur-[120px]" aria-hidden="true"></div>
-    <div
-      bind:this={orbRef}
-      class="pointer-events-none absolute right-10 top-10 h-44 w-44 rounded-full bg-secondary-500/30 opacity-40"
-      aria-hidden="true"
-    />
-  </div>
-
-  <div class="grid gap-12 lg:grid-cols-[minmax(0,1fr)_420px] lg:items-center">
-    <div class="space-y-7" use:fadeSlide={{ axis: 'y', from: 40 }}>
-      <div class="inline-flex items-center gap-3 rounded-full bg-primary-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.32em] text-primary-500">
-        {$t('app.brand_global')}
-      </div>
-      <h1 class="text-balance text-3xl font-semibold sm:text-4xl lg:text-5xl">
-        {$t('app.title')}
-      </h1>
-      <p class="max-w-2xl text-lg text-surface-600 dark:text-surface-300">
-        {$t('app.tagline')}
-      </p>
-      <div class="relative flex flex-col gap-4 rounded-3xl border border-primary-500/20 bg-white/70 p-6 backdrop-blur-xl shadow-glow dark:bg-surface-900/80 dark:text-surface-50" use:fadeSlide={{ delay: 0.08 }}>
-        <div class="absolute inset-y-0 right-0 hidden w-1/3 rounded-3xl bg-gradient-to-l from-primary-500/10 via-transparent to-transparent lg:block" aria-hidden="true"></div>
-        <div class="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <p class="text-sm font-semibold uppercase tracking-[0.2em] text-primary-400/80">
-              {$t('app.brand_available_offline')}
-            </p>
-            <!-- <p class="mt-2 max-w-xl text-sm text-surface-500 dark:text-surface-200">
-              {$t('app.search_placeholder')}
-            </p> -->
-          </div>
-          <div class="flex items-center gap-3 text-sm text-surface-500 dark:text-surface-200">
-            <span class="relative inline-flex h-10 w-10 items-center justify-center overflow-hidden rounded-full bg-primary-500/15">
-              <span class="absolute inset-0 animate-ping rounded-full bg-primary-500/20"></span>
-              <Sparkles class="relative h-4 w-4 text-primary-500" />
-            </span>
-            <span class="font-semibold">
-              {$t('app.toggle_index')}
-            </span>
-          </div>
+<section class="pt-12 sm:pt-16 lg:pt-20">
+  <div class="rounded-3xl border border-primary-500/15 bg-white/90 px-6 py-10 shadow-xl backdrop-blur-sm dark:border-surface-700/40 dark:bg-surface-900/80 sm:px-10">
+    <div class="grid gap-10 lg:grid-cols-2 lg:items-center">
+      <div class="space-y-6">
+        <p class="inline-flex items-center gap-2 rounded-full bg-primary-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-primary-500">
+          {$t('app.brand_global')}
+        </p>
+        <div class="space-y-4">
+          <h1 class="text-balance text-3xl font-semibold text-surface-900 dark:text-surface-50 sm:text-4xl lg:text-5xl">
+            {$t('app.title')}
+          </h1>
+          <p class="max-w-2xl text-base leading-relaxed text-surface-600 dark:text-surface-300">
+            {$t('app.tagline')}
+          </p>
         </div>
-        <div class="grid gap-3 sm:grid-cols-2" use:fadeSlide={{ delay: 0.15 }}>
-          <label class="group flex items-center justify-between gap-4 rounded-2xl border border-white/40 bg-white/80 px-4 py-3 text-sm font-semibold text-surface-700 shadow-sm transition dark:border-surface-700/50 dark:bg-surface-800/80 dark:text-surface-200">
-            <span class="flex items-center gap-3">
-              <Languages class="h-5 w-5 text-primary-500" />
-              <span class="uppercase tracking-[0.2em] text-xs text-surface-500 dark:text-surface-400">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <a
+            class="inline-flex items-center justify-center gap-2 rounded-full bg-primary-500 px-6 py-3 text-sm font-semibold text-white shadow-md transition hover:bg-primary-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+            href="#songbook-search"
+          >
+            <Search class="h-4 w-4" />
+            {$t('app.search_placeholder')}
+          </a>
+          <label class="flex w-full items-center justify-between gap-3 rounded-2xl border border-primary-500/10 bg-white/70 px-4 py-3 text-sm font-semibold text-surface-700 shadow-sm transition dark:border-surface-700/40 dark:bg-surface-900/70 dark:text-surface-200 sm:w-auto">
+            <span class="flex items-center gap-2">
+              <Languages class="h-4 w-4 text-primary-500" />
+              <span class="uppercase tracking-[0.16em] text-xs text-surface-500 dark:text-surface-400">
                 {$t('app.language_label')}
               </span>
             </span>
             <select
-              class="w-28 rounded-xl border border-transparent bg-transparent text-right text-sm font-semibold text-surface-700 outline-none transition focus-visible:border-primary-500 dark:text-surface-200"
+              class="rounded-xl border border-transparent bg-transparent text-right text-sm font-semibold text-surface-700 outline-none transition focus-visible:border-primary-500 dark:text-surface-200"
               bind:value={$language}
             >
               <option value="PL">Polski</option>
               <option value="EN">English</option>
             </select>
           </label>
-          <label class="group flex items-center justify-between gap-4 rounded-2xl border border-white/40 bg-white/80 px-4 py-3 text-sm font-semibold text-surface-700 shadow-sm transition dark:border-surface-700/50 dark:bg-surface-800/80 dark:text-surface-200">
-            <span class="flex items-center gap-3">
-              <Sun class="h-5 w-5 text-primary-500" />
-              <span class="uppercase tracking-[0.2em] text-xs text-surface-500 dark:text-surface-400">
-                {$t('app.theme_label')}
-              </span>
-            </span>
-            <select
-              class="w-32 rounded-xl border border-transparent bg-transparent text-right text-sm font-semibold text-surface-700 outline-none transition focus-visible:border-primary-500 dark:text-surface-200"
-              bind:value={$theme}
-            >
-              <option value="light">{$t('app.light')}</option>
-              <option value="dark">{$t('app.dark')}</option>
-              <option value="system">{$t('app.system')}</option>
-            </select>
-          </label>
         </div>
       </div>
-    </div>
 
-    <div class="relative" use:fadeSlide={{ axis: 'x', from: 50, delay: 0.1 }}>
-      <div class="gradient-border rounded-[2rem] bg-gradient-to-b from-white/70 via-white/50 to-white/70 p-1 dark:from-surface-800/80 dark:via-surface-900/80 dark:to-surface-800/80">
-        <div class="backdrop-glass relative flex h-full flex-col gap-6 rounded-[1.8rem] p-8">
-          <div class="flex items-center gap-4">
-            <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary-500/15">
-              <MoonStar class="h-6 w-6 text-primary-500" />
-            </div>
-            <div>
-              <p class="text-xs uppercase tracking-[0.35em] text-primary-400/80">{$t('app.brand_global')}</p>
-              <p class="text-lg font-semibold">{$t('app.toggle_index')}</p>
-            </div>
-          </div>
-          <p class="text-sm leading-relaxed text-surface-600 dark:text-surface-300">
-            {$t('app.tagline')}
+      <div class="space-y-6 rounded-2xl border border-primary-500/10 bg-white/70 p-6 shadow-inner dark:border-surface-700/40 dark:bg-surface-900/70">
+        <div class="space-y-2">
+          <p class="text-xs font-semibold uppercase tracking-[0.28em] text-primary-400/80">
+            {$t('app.brand_available_offline')}
           </p>
-          <div class="mt-auto space-y-4 text-sm text-surface-500 dark:text-surface-300">
-            <p class="font-semibold uppercase tracking-[0.25em] text-xs text-primary-400/90">{$t('app.syncing')}</p>
-            <div class="flex items-center gap-3">
-              <span class="inline-flex h-3 w-3 rounded-full bg-emerald-400 shadow-[0_0_0_6px_rgba(16,185,129,0.25)]"></span>
-              <span>{$syncingLabel || $t('app.brand_available_offline')}</span>
-            </div>
+          <p class="text-sm text-surface-500 dark:text-surface-300">
+            {$t('app.toggle_index')}
+          </p>
+        </div>
+        <div class="space-y-3 text-sm text-surface-600 dark:text-surface-200">
+          <div class="flex items-center justify-between rounded-xl border border-primary-500/10 bg-white/80 px-4 py-3 shadow-sm dark:border-surface-700/30 dark:bg-surface-900/60">
+            <span class="text-xs uppercase tracking-[0.2em] text-surface-500 dark:text-surface-400">{$t('app.syncing')}</span>
+            <span class="font-semibold">{$syncStatus}</span>
+          </div>
+          <div class="rounded-xl border border-primary-500/10 bg-white/80 px-4 py-3 shadow-sm dark:border-surface-700/30 dark:bg-surface-900/60">
+            <p class="text-xs uppercase tracking-[0.2em] text-surface-500 dark:text-surface-400">{$t('app.last_synced')}</p>
+            <p class="mt-1 font-semibold text-surface-800 dark:text-surface-100">{$lastSynced ? new Date($lastSynced).toLocaleString() : '—'}</p>
           </div>
         </div>
       </div>
     </div>
   </div>
-
-  <!-- <div class="mt-14 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-    {#each highlightCards as card, index}
-      <div
-        class="group relative overflow-hidden rounded-3xl border border-primary-500/10 bg-white/75 p-6 shadow-lg transition hover:-translate-y-1 hover:shadow-xl dark:border-surface-700/40 dark:bg-surface-800/80"
-        use:fadeSlide={{ delay: index * 0.12 }}
-      >
-        <div class="flex items-center gap-3">
-          <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-primary-500/10 text-primary-500">
-            <svelte:component this={card.icon} class="h-5 w-5" />
-          </span>
-          <div>
-            <p class="text-xs uppercase tracking-[0.25em] text-primary-400/80">{$t(card.label)}</p>
-            <p class="mt-1 text-base font-semibold text-surface-700 dark:text-surface-100">{$t(card.description)}</p>
-          </div>
-        </div>
-      </div>
-    {/each}
-  </div> -->
 </section>

--- a/src/lib/stores/preferences.ts
+++ b/src/lib/stores/preferences.ts
@@ -3,14 +3,10 @@ import { writable, derived } from 'svelte/store';
 import { locale } from 'svelte-i18n';
 import type { SongLanguage, SongViewMode } from '$lib/types/song';
 
-type Theme = 'light' | 'dark' | 'system';
-
-const THEME_KEY = 'songbook-theme';
 const LANGUAGE_KEY = 'songbook-language';
 const VIEW_KEY = 'songbook-view-mode';
 const FAV_KEY = 'songbook-favourites';
 
-const defaultTheme: Theme = 'light';
 const defaultLanguage: SongLanguage = 'PL';
 const defaultViewMode: SongViewMode = 'basic';
 
@@ -37,31 +33,11 @@ function createPersistedStore<T>(key: string, initial: T) {
   return store;
 }
 
-export const theme = createPersistedStore<Theme>(THEME_KEY, defaultTheme);
 export const language = createPersistedStore<SongLanguage>(LANGUAGE_KEY, defaultLanguage);
 export const viewMode = createPersistedStore<SongViewMode>(VIEW_KEY, defaultViewMode);
 export const favourites = createPersistedStore<string[]>(FAV_KEY, []);
 
-export const isDark = derived(theme, ($theme) => {
-  if (!browser) return false;
-  if ($theme === 'system') {
-    return window.matchMedia('(prefers-color-scheme: dark)').matches;
-  }
-  return $theme === 'dark';
-});
-
 if (browser) {
-  theme.subscribe(($theme) => {
-    const root = document.documentElement;
-    const resolved = $theme === 'system'
-      ? window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light'
-      : $theme;
-    root.dataset.theme = resolved;
-    root.classList.toggle('dark', resolved === 'dark');
-  });
-
   language.subscribe(($language) => {
     locale.set($language.toLowerCase());
     document.documentElement.lang = $language.toLowerCase();
@@ -74,6 +50,6 @@ export function toggleFavourite(key: string) {
   );
 }
 
-export const isFavourite = derived([favourites], ([$favourites]) => {
+export const isFavourite = derived(favourites, ($favourites) => {
   return (key: string) => $favourites.includes(key);
 });

--- a/src/lib/stores/theme.ts
+++ b/src/lib/stores/theme.ts
@@ -1,3 +1,0 @@
-import { writable } from 'svelte/store';
-
-export const theme = writable<'light' | 'dark'>('light');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,6 @@
   import { buildPageIndex, songsByPage } from '$lib/utils/pageIndex';
   import SongCard from '$lib/components/song/SongCard.svelte';
   import { fadeSlide } from '$lib/actions/fadeSlide';
-  import { inView } from '$lib/actions/inView';
   import { onMount } from 'svelte';
   import {
     Search,
@@ -29,7 +28,6 @@
   let pageFilter: number | null = null;
   let filtersOpen = browser ? false : true;
   let isDesktop = false;
-  let statsVisible = false;
   let activeViewMode: 'basic' | 'chords' = 'basic';
   let sortMode: SongSortMode = 'page';
   let searchRef: HTMLInputElement | null = null;
@@ -146,32 +144,41 @@
 </script>
 
 <section class="space-y-16 pb-12">
-  <div class="relative overflow-hidden rounded-[2.5rem] border border-primary-500/20 bg-white/80 px-6 py-8 shadow-2xl backdrop-blur-xl dark:border-surface-700/40 dark:bg-surface-900/80 sm:px-10" use:fadeSlide>
-    <div class="pointer-events-none absolute inset-0 -z-10">
-      <div class="absolute -left-10 top-0 h-64 w-64 rounded-full bg-primary-500/15 blur-[120px]"></div>
-      <div class="absolute bottom-0 right-0 h-52 w-52 rounded-full bg-secondary-400/20 blur-[110px]"></div>
-    </div>
-    <div class="flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between">
+  <div class="rounded-3xl border border-primary-500/15 bg-white/90 px-6 py-8 shadow-xl backdrop-blur-sm dark:border-surface-700/40 dark:bg-surface-900/80 sm:px-10" use:fadeSlide>
+    <div class="grid gap-10 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-center">
       <div class="space-y-6">
-        <div class="inline-flex items-center gap-2 rounded-full bg-primary-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-primary-500">
-          <Sparkles class="h-4 w-4" />
-          <span>{$t('app.search_placeholder')}</span>
-        </div>
+        <p class="inline-flex items-center gap-2 rounded-full bg-primary-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-primary-500">
+          {$t('app.brand_available_offline')}
+        </p>
         <div class="space-y-3">
-          <h2 class="text-balance text-3xl font-semibold sm:text-4xl">
+          <h2 class="text-balance text-3xl font-semibold text-surface-900 dark:text-surface-50 sm:text-4xl">
             {$t('app.toggle_index')}
           </h2>
           <p class="max-w-2xl text-base text-surface-600 dark:text-surface-300">
             {$t('app.tagline')}
           </p>
         </div>
+        <div class="grid gap-3 sm:grid-cols-3">
+          <div class="rounded-2xl border border-primary-500/10 bg-white/80 p-4 text-sm shadow-sm dark:border-surface-700/40 dark:bg-surface-900/70">
+            <p class="text-xs font-semibold uppercase tracking-[0.28em] text-primary-400/80">{$t('app.page_index')}</p>
+            <p class="mt-2 text-2xl font-semibold text-surface-900 dark:text-surface-50">{filteredSongs.length} / {availableSongs.length}</p>
+          </div>
+          <div class="rounded-2xl border border-primary-500/10 bg-white/80 p-4 text-sm shadow-sm dark:border-surface-700/40 dark:bg-surface-900/70">
+            <p class="text-xs font-semibold uppercase tracking-[0.28em] text-primary-400/80">{$t('app.toggle_favourites')}</p>
+            <p class="mt-2 text-2xl font-semibold text-surface-900 dark:text-surface-50">{favouriteSongs.length}</p>
+          </div>
+          <div class="rounded-2xl border border-primary-500/10 bg-white/80 p-4 text-sm shadow-sm dark:border-surface-700/40 dark:bg-surface-900/70">
+            <p class="text-xs font-semibold uppercase tracking-[0.28em] text-primary-400/80">{$t('app.view_song')}</p>
+            <p class="mt-2 text-2xl font-semibold text-surface-900 dark:text-surface-50">{$viewMode === 'basic' ? $t('app.view.basic') : $t('app.view.chords')}</p>
+          </div>
+        </div>
       </div>
-      <div class="w-full max-w-xl space-y-3">
+      <div id="songbook-search" class="space-y-3 rounded-2xl border border-primary-500/15 bg-white/85 p-6 shadow-inner dark:border-surface-700/40 dark:bg-surface-900/70">
         <label class="text-xs font-semibold uppercase tracking-[0.28em] text-surface-500 dark:text-surface-400" for="song-search">
           {$t('app.search_placeholder')}
         </label>
-        <div class="flex items-center gap-3 rounded-[1.75rem] border border-primary-500/20 bg-white/90 px-4 py-3 shadow-inner dark:border-surface-700/40 dark:bg-surface-800/80">
-          <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-primary-500/10 text-primary-500">
+        <div class="flex items-center gap-3 rounded-full border border-primary-500/20 bg-white/95 px-4 py-3 shadow-sm dark:border-surface-700/40 dark:bg-surface-800/80">
+          <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-primary-500/10 text-primary-500">
             <Search class="h-5 w-5" />
           </span>
           <input
@@ -193,28 +200,6 @@
           {/if}
         </div>
         <p class="text-xs text-surface-500 dark:text-surface-300">{$t('app.search_hint')}</p>
-      </div>
-    </div>
-    <div class="mt-10 grid gap-4 md:grid-cols-3" use:inView on:enterViewport={() => (statsVisible = true)}>
-      <div class="rounded-3xl border border-primary-500/15 bg-white/75 p-5 shadow-lg transition-all duration-500 dark:border-surface-700/40 dark:bg-surface-900/80" class:opacity-0={!statsVisible} class:translate-y-4={!statsVisible} class:opacity-100={statsVisible} class:translate-y-0={statsVisible}>
-        <p class="text-xs font-semibold uppercase tracking-[0.32em] text-primary-400/80">
-          {$t('app.page_index')}
-        </p>
-        <p class="mt-2 text-2xl font-semibold text-surface-800 dark:text-surface-100">{filteredSongs.length} / {availableSongs.length}</p>
-      </div>
-      <div class="rounded-3xl border border-primary-500/15 bg-white/75 p-5 shadow-lg transition-all duration-500 dark:border-surface-700/40 dark:bg-surface-900/80" class:opacity-0={!statsVisible} class:translate-y-4={!statsVisible} class:opacity-100={statsVisible} class:translate-y-0={statsVisible}>
-        <p class="text-xs font-semibold uppercase tracking-[0.32em] text-primary-400/80">
-          {$t('app.toggle_favourites')}
-        </p>
-        <p class="mt-2 text-2xl font-semibold text-surface-800 dark:text-surface-100">{favouriteSongs.length}</p>
-      </div>
-      <div class="rounded-3xl border border-primary-500/15 bg-white/75 p-5 shadow-lg transition-all duration-500 dark:border-surface-700/40 dark:bg-surface-900/80" class:opacity-0={!statsVisible} class:translate-y-4={!statsVisible} class:opacity-100={statsVisible} class:translate-y-0={statsVisible}>
-        <p class="text-xs font-semibold uppercase tracking-[0.32em] text-primary-400/80">
-          {$t('app.view_song')}
-        </p>
-        <p class="mt-2 text-2xl font-semibold text-surface-800 dark:text-surface-100">
-          {$viewMode === 'basic' ? $t('app.view.basic') : $t('app.view.chords')}
-        </p>
       </div>
     </div>
   </div>

--- a/src/routes/song/[id]/+page.svelte
+++ b/src/routes/song/[id]/+page.svelte
@@ -12,7 +12,6 @@
   let loading = true;
   let activeViewMode: 'basic' | 'chords' = 'basic';
   let lastUpdatedLabel: string | null = null;
-  let showScrollTop = false;
 
   onMount(async () => {
     const $page = get(page);
@@ -23,19 +22,6 @@
     }
     song = await getSongByKey(`${$page.params.id}-${activeLang}`);
     loading = false;
-  });
-
-  onMount(() => {
-    const updateScrollIndicator = () => {
-      showScrollTop = typeof window !== 'undefined' && window.scrollY > 240;
-    };
-
-    updateScrollIndicator();
-    window.addEventListener('scroll', updateScrollIndicator, { passive: true });
-
-    return () => {
-      window.removeEventListener('scroll', updateScrollIndicator);
-    };
   });
 
   $: favouriteKey = song ? `${song.id}-${song.language}` : '';
@@ -66,11 +52,6 @@
     }
   }
 
-  function scrollToTop() {
-    if (typeof window !== 'undefined') {
-      window.scrollTo({ top: 0, behavior: 'smooth' });
-    }
-  }
 </script>
 
 <svelte:head>
@@ -207,16 +188,6 @@
       {/each}
     </section>
   </article>
-  {#if showScrollTop}
-    <button
-      class="fixed bottom-6 right-6 inline-flex items-center gap-2 rounded-full border border-primary-500/20 bg-white/80 px-5 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-primary-500 shadow-lg backdrop-blur transition hover:-translate-y-0.5 hover:border-primary-500 hover:text-primary-500 dark:border-surface-700/40 dark:bg-surface-900/80"
-      type="button"
-      on:click={scrollToTop}
-      aria-label={$t('app.scroll_to_top')}
-    >
-      {$t('app.scroll_to_top')}
-    </button>
-  {/if}
 {:else}
   <div class="py-20 text-center text-sm text-[rgb(var(--text-secondary))]">Song not found.</div>
 {/if}


### PR DESCRIPTION
## Summary
- rebuild the home hero header with a streamlined call-to-action and sync status card
- refresh the landing page search section with simplified stats and anchors
- remove the persisted theme toggle and back-to-top button from the song detail view

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68da4c76a8048327b618a088efad2c7e