### PR TITLE
feat: modernize song list and add theme controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 			},
 			"devDependencies": {
 				"@eslint/compat": "^1.3.0",
-				"@sveltejs/adapter-auto": "^6.0.1",
+				"@sveltejs/adapter-static": "^3.0.7",
 				"@sveltejs/kit": "^2.22.0",
 				"@sveltejs/vite-plugin-svelte": "^3.1.2",
 				"@tailwindcss/postcss": "^4.1.13",
@@ -500,6 +500,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
 			"integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@eslint/object-schema": "^2.1.6",
 				"debug": "^4.3.1",
@@ -514,6 +515,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
 			"integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
@@ -536,6 +538,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
 			"integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -559,6 +562,7 @@
 			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
 			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -583,6 +587,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
 			"integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
@@ -592,6 +597,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
 			"integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@eslint/core": "^0.15.2",
 				"levn": "^0.4.1"
@@ -605,6 +611,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
 			"integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.15"
 			},
@@ -668,6 +675,7 @@
 			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
 			"integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=18.18.0"
 			}
@@ -677,6 +685,7 @@
 			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
 			"integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@humanfs/core": "^0.19.1",
 				"@humanwhocodes/retry": "^0.4.0"
@@ -690,6 +699,7 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
 			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=12.22"
 			},
@@ -703,6 +713,7 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
 			"integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=18.18"
 			},
@@ -1232,10 +1243,10 @@
 				"acorn": "^8.9.0"
 			}
 		},
-		"node_modules/@sveltejs/adapter-auto": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-6.1.0.tgz",
-			"integrity": "sha512-shOuLI5D2s+0zTv2ab5M5PqfknXqWbKi+0UwB9yLTRIdzsK1R93JOO8jNhIYSHdW+IYXIYnLniu+JZqXs7h9Wg==",
+		"node_modules/@sveltejs/adapter-static": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-3.0.9.tgz",
+			"integrity": "sha512-aytHXcMi7lb9ljsWUzXYQ0p5X1z9oWud2olu/EpmH7aCu4m84h7QLvb5Wp+CFirKcwoNnYvYWhyP/L8Vh1ztdw==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -1248,7 +1259,6 @@
 			"integrity": "sha512-44Mm5csR4mesKx2Eyhtk8UVrLJ4c04BT2wMTfYGKJMOkUqpHP5KLL2DPV0hXUA4t4+T3ZYe0aBygd42lVYv2cA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
@@ -1288,7 +1298,6 @@
 			"integrity": "sha512-Txsm1tJvtiYeLUVRNqxZGKR/mI+CzuIQuc2gn+YCs9rMTowpNZ2Nqt53JdL8KF9bLhAf2ruR/dr9eZCwdTriRA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^2.1.0",
 				"debug": "^4.3.4",
@@ -1734,7 +1743,6 @@
 			"integrity": "sha512-EHrrEsyhOhxYt8MTg4zTF+DJMuNBzWwgvvOYNj/zm1vnaD/IC5zCXFehZv94Piqa2cRFfXrTFxIvO95L7Qc/cw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.44.1",
 				"@typescript-eslint/types": "8.44.1",
@@ -1970,7 +1978,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1992,6 +1999,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -2008,6 +2016,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -2022,7 +2031,8 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"license": "Python-2.0"
+			"license": "Python-2.0",
+			"peer": true
 		},
 		"node_modules/aria-query": {
 			"version": "5.3.2",
@@ -2101,6 +2111,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
 			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -2139,7 +2150,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.3",
 				"caniuse-lite": "^1.0.30001741",
@@ -2159,6 +2169,7 @@
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -2189,6 +2200,7 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -2269,6 +2281,7 @@
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -2280,13 +2293,15 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cookie": {
 			"version": "0.6.0",
@@ -2303,6 +2318,7 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
 			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -2377,7 +2393,8 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/deepmerge": {
 			"version": "4.3.1",
@@ -2531,6 +2548,7 @@
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -2665,6 +2683,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
 			"integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.15"
 			},
@@ -2716,6 +2735,7 @@
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
 			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
@@ -2785,7 +2805,8 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/fast-glob": {
 			"version": "3.3.3",
@@ -2821,13 +2842,15 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/fastq": {
 			"version": "1.19.1",
@@ -2862,6 +2885,7 @@
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
 			"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"flat-cache": "^4.0.0"
 			},
@@ -2887,6 +2911,7 @@
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -2903,6 +2928,7 @@
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
 			"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"flatted": "^3.2.9",
 				"keyv": "^4.5.4"
@@ -2915,7 +2941,8 @@
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
 			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/fraction.js": {
 			"version": "4.3.7",
@@ -2978,6 +3005,7 @@
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
 			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"is-glob": "^4.0.3"
 			},
@@ -3028,6 +3056,7 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -3043,6 +3072,7 @@
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
 			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -3052,6 +3082,7 @@
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
 			"integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
@@ -3068,6 +3099,7 @@
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.8.19"
 			}
@@ -3134,7 +3166,8 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/jiti": {
 			"version": "2.6.0",
@@ -3151,6 +3184,7 @@
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -3162,25 +3196,29 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
 			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
 			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"json-buffer": "3.0.1"
 			}
@@ -3232,6 +3270,7 @@
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
 			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
@@ -3499,6 +3538,7 @@
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"p-locate": "^5.0.0"
 			},
@@ -3513,7 +3553,8 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/lru-queue": {
 			"version": "0.1.0",
@@ -3609,6 +3650,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -3739,6 +3781,7 @@
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
 			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
@@ -3756,6 +3799,7 @@
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
 			},
@@ -3771,6 +3815,7 @@
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
@@ -3786,6 +3831,7 @@
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"callsites": "^3.0.0"
 			},
@@ -3798,6 +3844,7 @@
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -3807,6 +3854,7 @@
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -3847,7 +3895,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -3981,6 +4028,7 @@
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 0.8.0"
 			}
@@ -3991,7 +4039,6 @@
 			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -4018,6 +4065,7 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -4062,6 +4110,7 @@
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -4179,6 +4228,7 @@
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
 			},
@@ -4191,6 +4241,7 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -4224,6 +4275,7 @@
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -4236,6 +4288,7 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -4248,7 +4301,6 @@
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.20.tgz",
 			"integrity": "sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.15",
@@ -4368,8 +4420,7 @@
 			"version": "4.1.13",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
 			"integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/tapable": {
 			"version": "2.2.3",
@@ -4484,6 +4535,7 @@
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
 			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1"
 			},
@@ -4497,7 +4549,6 @@
 			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -4572,6 +4623,7 @@
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
@@ -4602,7 +4654,6 @@
 			"integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.21.3",
 				"postcss": "^8.4.43",
@@ -5136,6 +5187,7 @@
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"isexe": "^2.0.0"
 			},
@@ -5151,6 +5203,7 @@
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
 			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -5200,6 +5253,7 @@
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	},
 	"devDependencies": {
 		"@eslint/compat": "^1.3.0",
-		"@sveltejs/adapter-auto": "^6.0.1",
+                "@sveltejs/adapter-static": "^3.0.7",
 		"@sveltejs/kit": "^2.22.0",
 		"@sveltejs/vite-plugin-svelte": "^3.1.2",
 		"@tailwindcss/postcss": "^4.1.13",

--- a/src/app.css
+++ b/src/app.css
@@ -12,12 +12,7 @@
 
   body {
     font-family: Inter, 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    @apply bg-surface-50 text-surface-900 dark:bg-surface-900 dark:text-surface-50 min-h-screen antialiased;
-    background-image:
-      radial-gradient(circle at 15% 20%, rgba(14, 165, 233, 0.28), transparent 60%),
-      radial-gradient(circle at 80% 10%, rgba(99, 102, 241, 0.23), transparent 55%),
-      radial-gradient(circle at 40% 85%, rgba(56, 189, 248, 0.18), transparent 55%);
-    background-attachment: fixed;
+    @apply min-h-screen bg-transparent text-surface-900 antialiased dark:text-surface-50;
   }
 
   body.is-lenis {

--- a/src/lib/components/layout/AppHeader.svelte
+++ b/src/lib/components/layout/AppHeader.svelte
@@ -1,45 +1,52 @@
 <script lang="ts">
   import { t } from 'svelte-i18n';
-  import { language } from '$lib/stores/preferences';
+  import { language, theme, toggleTheme } from '$lib/stores/preferences';
   import { isSyncing, lastSynced } from '$lib/stores/songStore';
   import { derived } from 'svelte/store';
-  import { Languages, Search } from 'lucide-svelte';
+  import { Languages, Moon, Search, Sun } from 'lucide-svelte';
 
   const syncStatus = derived(isSyncing, ($isSyncing) => ($isSyncing ? $t('app.syncing') : $t('app.brand_available_offline')));
 </script>
 
-<section class="pt-12 sm:pt-16 lg:pt-20">
-  <div class="rounded-3xl border border-primary-500/15 bg-white/90 px-6 py-10 shadow-xl backdrop-blur-sm dark:border-surface-700/40 dark:bg-surface-900/80 sm:px-10">
-    <div class="grid gap-10 lg:grid-cols-2 lg:items-center">
-      <div class="space-y-6">
-        <p class="inline-flex items-center gap-2 rounded-full bg-primary-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-primary-500">
-          {$t('app.brand_global')}
-        </p>
-        <div class="space-y-4">
-          <h1 class="text-balance text-3xl font-semibold text-surface-900 dark:text-surface-50 sm:text-4xl lg:text-5xl">
+<section class="pt-10 sm:pt-12 lg:pt-14">
+  <div class="rounded-2xl border border-surface-200/70 bg-white/80 p-6 shadow-sm backdrop-blur dark:border-surface-800/60 dark:bg-surface-900/70 sm:p-8">
+    <div class="flex flex-col gap-6">
+      <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div class="space-y-2">
+          <p class="text-xs font-semibold uppercase tracking-[0.3em] text-primary-500">
+            {$t('app.brand_global')}
+          </p>
+          <h1 class="text-balance text-3xl font-semibold text-surface-900 dark:text-surface-50 sm:text-4xl">
             {$t('app.title')}
           </h1>
-          <p class="max-w-2xl text-base leading-relaxed text-surface-600 dark:text-surface-300">
+          <p class="max-w-2xl text-sm leading-relaxed text-surface-600 dark:text-surface-300">
             {$t('app.tagline')}
           </p>
         </div>
-        <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
-          <a
-            class="inline-flex items-center justify-center gap-2 rounded-full bg-primary-500 px-6 py-3 text-sm font-semibold text-white shadow-md transition hover:bg-primary-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
-            href="#songbook-search"
+        <div class="flex flex-wrap items-center gap-2 sm:justify-end">
+          <button
+            class="inline-flex items-center gap-2 rounded-full border border-surface-200/80 bg-white px-4 py-2 text-sm font-semibold text-surface-700 shadow-sm transition hover:border-primary-400 hover:text-primary-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:border-surface-700 dark:bg-surface-800/90 dark:text-surface-200"
+            on:click={toggleTheme}
+            type="button"
+            aria-label={$theme === 'dark'
+              ? `${$t('app.theme_label')} – ${$t('app.theme.light')}`
+              : `${$t('app.theme_label')} – ${$t('app.theme.dark')}`}
           >
-            <Search class="h-4 w-4" />
-            {$t('app.search_placeholder')}
-          </a>
-          <label class="flex w-full items-center justify-between gap-3 rounded-2xl border border-primary-500/10 bg-white/70 px-4 py-3 text-sm font-semibold text-surface-700 shadow-sm transition dark:border-surface-700/40 dark:bg-surface-900/70 dark:text-surface-200 sm:w-auto">
-            <span class="flex items-center gap-2">
-              <Languages class="h-4 w-4 text-primary-500" />
-              <span class="uppercase tracking-[0.16em] text-xs text-surface-500 dark:text-surface-400">
-                {$t('app.language_label')}
-              </span>
+            {#if $theme === 'dark'}
+              <Sun class="h-4 w-4" />
+              <span class="text-xs font-semibold uppercase tracking-[0.2em]">{$t('app.theme.light') ?? 'Light'}</span>
+            {:else}
+              <Moon class="h-4 w-4" />
+              <span class="text-xs font-semibold uppercase tracking-[0.2em]">{$t('app.theme.dark') ?? 'Dark'}</span>
+            {/if}
+          </button>
+          <label class="inline-flex items-center gap-2 rounded-full border border-surface-200/80 bg-white px-4 py-2 text-sm font-semibold text-surface-700 shadow-sm transition hover:border-primary-400 focus-within:ring-2 focus-within:ring-primary-400 focus-within:ring-offset-2 focus-within:ring-offset-white dark:border-surface-700 dark:bg-surface-800/90 dark:text-surface-200 dark:focus-within:ring-offset-surface-900">
+            <Languages class="h-4 w-4 text-primary-500" />
+            <span class="text-xs font-semibold uppercase tracking-[0.2em] text-surface-500 dark:text-surface-400">
+              {$t('app.language_label')}
             </span>
             <select
-              class="rounded-xl border border-transparent bg-transparent text-right text-sm font-semibold text-surface-700 outline-none transition focus-visible:border-primary-500 dark:text-surface-200"
+              class="rounded-full border-none bg-transparent text-sm font-semibold text-surface-700 outline-none dark:text-surface-200"
               bind:value={$language}
             >
               <option value="PL">Polski</option>
@@ -48,25 +55,23 @@
           </label>
         </div>
       </div>
-
-      <div class="space-y-6 rounded-2xl border border-primary-500/10 bg-white/70 p-6 shadow-inner dark:border-surface-700/40 dark:bg-surface-900/70">
-        <div class="space-y-2">
-          <p class="text-xs font-semibold uppercase tracking-[0.28em] text-primary-400/80">
-            {$t('app.brand_available_offline')}
+      <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <a
+          class="inline-flex items-center justify-center gap-2 rounded-full bg-primary-500 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          href="#songbook-search"
+        >
+          <Search class="h-4 w-4" />
+          {$t('app.search_placeholder')}
+        </a>
+        <div class="flex flex-col gap-2 text-sm text-surface-600 dark:text-surface-300 sm:flex-row sm:items-center">
+          <p class="flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] dark:border-surface-700 dark:bg-surface-800/80">
+            <span class="text-surface-500 dark:text-surface-400">{$t('app.syncing')}</span>
+            <span class="text-surface-900 dark:text-surface-100">{$syncStatus}</span>
           </p>
-          <p class="text-sm text-surface-500 dark:text-surface-300">
-            {$t('app.toggle_index')}
+          <p class="flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] dark:border-surface-700 dark:bg-surface-800/80">
+            <span class="text-surface-500 dark:text-surface-400">{$t('app.last_synced')}</span>
+            <span class="text-surface-900 dark:text-surface-100">{$lastSynced ? new Date($lastSynced).toLocaleString() : '—'}</span>
           </p>
-        </div>
-        <div class="space-y-3 text-sm text-surface-600 dark:text-surface-200">
-          <div class="flex items-center justify-between rounded-xl border border-primary-500/10 bg-white/80 px-4 py-3 shadow-sm dark:border-surface-700/30 dark:bg-surface-900/60">
-            <span class="text-xs uppercase tracking-[0.2em] text-surface-500 dark:text-surface-400">{$t('app.syncing')}</span>
-            <span class="font-semibold">{$syncStatus}</span>
-          </div>
-          <div class="rounded-xl border border-primary-500/10 bg-white/80 px-4 py-3 shadow-sm dark:border-surface-700/30 dark:bg-surface-900/60">
-            <p class="text-xs uppercase tracking-[0.2em] text-surface-500 dark:text-surface-400">{$t('app.last_synced')}</p>
-            <p class="mt-1 font-semibold text-surface-800 dark:text-surface-100">{$lastSynced ? new Date($lastSynced).toLocaleString() : '—'}</p>
-          </div>
         </div>
       </div>
     </div>

--- a/src/lib/components/song/SongCard.svelte
+++ b/src/lib/components/song/SongCard.svelte
@@ -89,37 +89,36 @@
 <div use:inView on:enterViewport={handleEnter}>
   {#if visible}
     <article
-      class="relative overflow-hidden rounded-[1.9rem] border border-primary-500/15 bg-white/80 p-6 shadow-xl backdrop-blur-xl transition hover:-translate-y-1 hover:shadow-2xl dark:border-surface-700/40 dark:bg-surface-900/80"
+      class="rounded-2xl border border-surface-200/70 bg-white p-5 shadow-sm transition hover:-translate-y-1 hover:shadow-lg dark:border-surface-700 dark:bg-surface-900/70"
       use:listTransition={index}
     >
-      <div class="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-primary-500 via-secondary-400 to-primary-500 opacity-70"></div>
       <div class="flex flex-col gap-6">
         <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div class="space-y-4">
             <div class="space-y-2">
-              <h3 class="text-2xl font-semibold text-surface-800 dark:text-surface-50">{song.title}</h3>
+              <h3 class="text-xl font-semibold text-surface-900 dark:text-surface-50">{song.title}</h3>
               {#if lastUpdatedLabel}
-                <p class="text-xs uppercase tracking-[0.32em] text-primary-400/80">
+                <p class="text-xs text-surface-500 dark:text-surface-400">
                   {$t('app.updated_label')}: {lastUpdatedLabel}
                 </p>
               {/if}
             </div>
             <div class="flex flex-wrap items-center gap-2 text-xs text-surface-500 dark:text-surface-300">
-              <span class="rounded-full bg-primary-500/10 px-3 py-1 font-semibold uppercase tracking-[0.2em] text-primary-500">
+              <span class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3 py-1 font-medium text-surface-700 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-100">
                 {$t('app.page_label')} {song.page}
               </span>
-              <span class="rounded-full bg-white/80 px-3 py-1 text-surface-500 dark:bg-surface-800/80 dark:text-surface-300">
+              <span class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3 py-1 text-surface-600 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200">
                 {$t('app.source_label')} {song.source}
               </span>
-              <span class="rounded-full bg-white/80 px-3 py-1 text-surface-500 dark:bg-surface-800/80 dark:text-surface-300">
+              <span class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3 py-1 text-surface-600 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200">
                 {$t('app.external_index')} {song.externalIndex}
               </span>
             </div>
           </div>
           <div class="flex flex-wrap justify-end gap-2 text-sm">
             <button
-              class={`inline-flex items-center justify-center gap-2 rounded-full border border-primary-500/40 px-5 py-2 font-semibold transition hover:-translate-y-0.5 hover:border-primary-500 hover:bg-primary-500/10 ${
-                isFavourite ? 'bg-primary-500/15 text-primary-600 dark:text-primary-300' : 'text-primary-600 dark:text-primary-200'
+              class={`inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-4 py-2 font-medium transition hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200 ${
+                isFavourite ? 'bg-primary-500/10 text-primary-600 dark:text-primary-300' : 'text-surface-700'
               }`}
               on:click={() => dispatch('toggleFavourite', `${song.id}-${song.language}`)}
               type="button"
@@ -128,7 +127,7 @@
               {isFavourite ? $t('app.remove_favourite') : $t('app.add_favourite')}
             </button>
             <button
-              class="inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-primary-500 to-secondary-400 px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:shadow-xl"
+              class="inline-flex items-center gap-2 rounded-full bg-primary-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-600"
               on:click={() => dispatch('open', song)}
               type="button"
             >
@@ -137,7 +136,7 @@
             </button>
             {#if remainingItems.length}
               <button
-                class="inline-flex items-center justify-center gap-2 rounded-full border border-primary-500/25 px-5 py-2 text-sm font-semibold text-surface-600 transition hover:-translate-y-0.5 hover:border-primary-500 hover:text-primary-500 dark:border-surface-700/40 dark:text-surface-200"
+                class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-4 py-2 text-sm font-medium text-surface-600 transition hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200"
                 on:click={() => (expanded = !expanded)}
                 type="button"
                 aria-expanded={expanded}
@@ -152,7 +151,7 @@
               </button>
             {/if}
             <button
-              class="inline-flex items-center justify-center gap-2 rounded-full border border-primary-500/25 px-5 py-2 text-sm font-semibold text-surface-600 transition hover:-translate-y-0.5 hover:border-primary-500 hover:text-primary-500 dark:border-surface-700/40 dark:text-surface-200"
+              class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-4 py-2 text-sm font-medium text-surface-600 transition hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200"
               on:click={copyShareLink}
               type="button"
             >
@@ -162,19 +161,19 @@
           </div>
         </div>
 
-        <div class="rounded-2xl border border-primary-500/15 bg-white/70 p-4 text-xs shadow-inner dark:border-surface-700/40 dark:bg-surface-900/70">
+        <div class="rounded-xl border border-surface-200/70 bg-white px-4 py-4 text-xs dark:border-surface-700 dark:bg-surface-900/70">
           <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <p class="font-semibold uppercase tracking-[0.3em] text-primary-400/80">{$t('app.density_label')}</p>
+              <p class="text-xs font-semibold uppercase tracking-[0.2em] text-primary-500/90">{$t('app.density_label')}</p>
               <div class="mt-2 flex items-center gap-3">
-                <span class="relative inline-flex h-2 w-36 overflow-hidden rounded-full bg-primary-500/10">
+                <span class="relative inline-flex h-2 w-36 overflow-hidden rounded-full bg-surface-200/70 dark:bg-surface-800">
                   <span
-                    class="absolute inset-y-0 left-0 origin-left rounded-full bg-gradient-to-r from-primary-500 to-secondary-400"
+                    class="absolute inset-y-0 left-0 origin-left rounded-full bg-primary-500"
                     style:transform={`scaleX(${Math.max(density, 0.05)})`}
                     style:transition={prefersReducedMotion ? 'none' : 'transform 420ms cubic-bezier(0.22, 1, 0.36, 1)'}
                   />
                 </span>
-                <span class="text-sm font-semibold text-surface-700 dark:text-surface-200">{densityPercentage}%</span>
+                <span class="text-sm font-semibold text-surface-700 dark:text-surface-100">{densityPercentage}%</span>
               </div>
             </div>
             <p class="text-xs text-surface-500 dark:text-surface-300">
@@ -189,7 +188,7 @@
               class={`whitespace-pre-line ${alignmentClass(item.alignment)} ${item.isBold ? 'font-semibold' : ''} ${item.isItalics ? 'italic' : ''}`}
             >
               {#if viewMode === 'chords' && item.type === 'CHORD'}
-                <span class="block text-xs font-semibold uppercase tracking-[0.3em] text-primary-400/80">CHORDS</span>
+                <span class="block text-[11px] font-semibold text-primary-500">CHORDS</span>
                 <span class="mt-1 block text-base font-medium">{item.text}</span>
               {:else}
                 {item.text}
@@ -210,7 +209,7 @@
                 class={`whitespace-pre-line ${alignmentClass(item.alignment)} ${item.isBold ? 'font-semibold' : ''} ${item.isItalics ? 'italic' : ''}`}
               >
                 {#if viewMode === 'chords' && item.type === 'CHORD'}
-                  <span class="block text-xs font-semibold uppercase tracking-[0.3em] text-primary-400/80">CHORDS</span>
+                  <span class="block text-[11px] font-semibold text-primary-500">CHORDS</span>
                   <span class="mt-1 block text-base font-medium">{item.text}</span>
                 {:else}
                   {item.text}

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -5,6 +5,10 @@
     "search_placeholder": "Search by title, lyric, page or index…",
     "language_label": "Language",
     "theme_label": "Theme",
+    "theme": {
+        "light": "Light",
+        "dark": "Dark"
+    },
     "light": "Light",
     "dark": "Dark",
     "system": "System",

--- a/src/lib/locales/pl.json
+++ b/src/lib/locales/pl.json
@@ -5,6 +5,10 @@
     "search_placeholder": "Szukaj po tytule, tekście, stronie lub indeksie…",
     "language_label": "Język",
     "theme_label": "Motyw",
+    "theme": {
+        "light": "Jasny",
+        "dark": "Ciemny"
+    },
     "light": "Jasny",
     "dark": "Ciemny",
     "system": "Systemowy",

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -59,26 +59,15 @@
   });
 </script>
 
-<div class="relative isolate overflow-hidden">
-  <div
-    class="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_20%_10%,rgba(99,102,241,0.35),transparent_60%),radial-gradient(circle_at_80%_5%,rgba(34,211,238,0.24),transparent_55%),radial-gradient(circle_at_50%_90%,rgba(14,165,233,0.22),transparent_60%)]"
-    aria-hidden="true"
-  ></div>
-  <div class="relative mx-auto flex min-h-screen w-full max-w-[120rem] flex-col px-4 pb-24 sm:px-6 lg:px-12">
+<div class="min-h-screen bg-gradient-to-b from-surface-50 via-surface-100 to-surface-50 text-surface-900 dark:from-surface-950 dark:via-surface-900 dark:to-surface-950">
+  <div class="mx-auto flex min-h-screen w-full max-w-6xl flex-col px-4 pb-16 sm:px-6 lg:px-8">
     <AppHeader />
-    <main class="flex-1 py-10 sm:py-12 lg:py-16">
+    <main class="flex-1 py-8 sm:py-10 lg:py-12">
       <slot />
     </main>
-    <footer class="mt-10 flex flex-col gap-3 py-8 text-sm text-surface-500 dark:text-surface-400">
-      <span class="uppercase tracking-[0.25em] text-xs font-semibold text-primary-400/80">Songbook</span>
-      <p class="max-w-xl leading-relaxed text-surface-600 dark:text-surface-300">
-        Designed for worship leaders and musicians who need an offline-first, international-ready song
-        companion.
-      </p>
+    <footer class="mt-12 border-t border-surface-200/60 py-6 text-sm text-surface-500 dark:border-surface-800 dark:text-surface-400">
+      <p class="font-semibold uppercase tracking-[0.2em] text-xs text-primary-500/80">Songbook</p>
+      <p class="mt-2 max-w-xl leading-relaxed">Designed for musicians who need a simple, dependable song companion offline.</p>
     </footer>
   </div>
-  <div
-    class="pointer-events-none absolute inset-x-1/2 top-[20%] h-[38rem] w-[38rem] -translate-x-1/2 rounded-full bg-primary-500/10 blur-[220px]"
-    aria-hidden="true"
-  ></div>
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,55 +2,39 @@
   import { t } from 'svelte-i18n';
   import { browser } from '$app/environment';
   import { goto } from '$app/navigation';
-  import { language, favourites, viewMode, toggleFavourite } from '$lib/stores/preferences';
-  import { searchableSongs, songs, filterSongs, type SongSortMode } from '$lib/stores/songStore';
+  import { favourites, language, toggleFavourite, viewMode } from '$lib/stores/preferences';
+  import { filterSongs, searchableSongs, songs, type SongSortMode } from '$lib/stores/songStore';
   import { buildPageIndex, songsByPage } from '$lib/utils/pageIndex';
   import SongCard from '$lib/components/song/SongCard.svelte';
   import { fadeSlide } from '$lib/actions/fadeSlide';
   import { onMount } from 'svelte';
-  import {
-    Search,
-    Filter,
-    Heart,
-    LayoutList,
-    Sparkles,
-    ChevronDown,
-    ChevronUp,
-    MapPinned,
-    ArrowDownAZ,
-    Clock3,
-    BarChart3
-  } from 'lucide-svelte';
+  import { ArrowUp, Heart, LayoutList, Search } from 'lucide-svelte';
   import type { Song } from '$lib/types/song';
 
   let query = '';
   let menuView: 'index' | 'favourites' = 'index';
   let pageFilter: number | null = null;
-  let filtersOpen = browser ? false : true;
-  let isDesktop = false;
   let activeViewMode: 'basic' | 'chords' = 'basic';
   let sortMode: SongSortMode = 'page';
   let searchRef: HTMLInputElement | null = null;
   let pageSearch = '';
-  let openGroup: string | null = null;
+  let showScrollTop = false;
 
-  const sortOptions: { value: SongSortMode; label: string; icon: typeof MapPinned }[] = [
-    { value: 'page', label: 'app.sort.page', icon: MapPinned },
-    { value: 'alpha', label: 'app.sort.alpha', icon: ArrowDownAZ },
-    { value: 'recent', label: 'app.sort.recent', icon: Clock3 },
-    { value: 'dense', label: 'app.sort.dense', icon: BarChart3 }
+  const sortOptions: { value: SongSortMode; label: string }[] = [
+    { value: 'page', label: 'app.sort.page' },
+    { value: 'alpha', label: 'app.sort.alpha' },
+    { value: 'recent', label: 'app.sort.recent' },
+    { value: 'dense', label: 'app.sort.dense' }
   ];
 
   onMount(() => {
     if (!browser) return;
-    const update = () => {
-      const desktop = window.innerWidth >= 1200;
-      isDesktop = desktop;
-      filtersOpen = desktop;
+    const updateScrollState = () => {
+      showScrollTop = window.scrollY > 320;
     };
-    update();
-    window.addEventListener('resize', update, { passive: true });
-    return () => window.removeEventListener('resize', update);
+    updateScrollState();
+    window.addEventListener('scroll', updateScrollState, { passive: true });
+    return () => window.removeEventListener('scroll', updateScrollState);
   });
 
   $: activeViewMode = $viewMode;
@@ -77,14 +61,6 @@
     pageSearch.trim() ? $t('app.filters.page_search', { values: { query: pageSearch.trim() } }) : null
   ].filter((badge): badge is string => Boolean(badge));
 
-  $: {
-    if (pageGroups.length === 0) {
-      openGroup = null;
-    } else if (!openGroup || !pageGroups.some((group) => group.label === openGroup)) {
-      openGroup = pageGroups[0]?.label ?? null;
-    }
-  }
-
   function matchesPageSearch(pageNumber: number) {
     const trimmed = pageSearch.trim();
     if (!trimmed) return true;
@@ -95,17 +71,11 @@
     return group.pages.filter((pageNumber) => matchesPageSearch(pageNumber));
   }
 
-  function toggleGroup(label: string) {
-    openGroup = openGroup === label ? null : label;
-  }
-
   function handleClearFilters() {
     query = '';
     pageFilter = null;
     menuView = 'index';
-    filtersOpen = isDesktop;
     pageSearch = '';
-    openGroup = pageGroups[0]?.label ?? null;
   }
 
   function openSong(song: Song) {
@@ -117,21 +87,6 @@
     menuView = 'index';
   }
 
-  function focusSearchInput() {
-    if (!browser) return;
-    filtersOpen = true;
-    menuView = 'index';
-    searchRef?.focus();
-    searchRef?.select();
-  }
-
-  function openFavouritesQuickly() {
-    filtersOpen = true;
-    menuView = 'favourites';
-    if (!browser) return;
-    document.getElementById('songbook-filters')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  }
-
   function handleViewTabKeydown(event: KeyboardEvent, mode: 'basic' | 'chords') {
     if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight' && event.key !== 'ArrowUp' && event.key !== 'ArrowDown') {
       return;
@@ -141,406 +96,262 @@
     const next = mode === 'basic' ? 'chords' : 'basic';
     viewMode.set(next);
   }
+
+  function scrollToTop() {
+    if (!browser) return;
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
 </script>
 
-<section class="space-y-16 pb-12">
-  <div class="rounded-3xl border border-primary-500/15 bg-white/90 px-6 py-8 shadow-xl backdrop-blur-sm dark:border-surface-700/40 dark:bg-surface-900/80 sm:px-10" use:fadeSlide>
-    <div class="grid gap-10 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-center">
-      <div class="space-y-6">
-        <p class="inline-flex items-center gap-2 rounded-full bg-primary-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-primary-500">
-          {$t('app.brand_available_offline')}
-        </p>
-        <div class="space-y-3">
-          <h2 class="text-balance text-3xl font-semibold text-surface-900 dark:text-surface-50 sm:text-4xl">
-            {$t('app.toggle_index')}
-          </h2>
-          <p class="max-w-2xl text-base text-surface-600 dark:text-surface-300">
-            {$t('app.tagline')}
-          </p>
-        </div>
-        <div class="grid gap-3 sm:grid-cols-3">
-          <div class="rounded-2xl border border-primary-500/10 bg-white/80 p-4 text-sm shadow-sm dark:border-surface-700/40 dark:bg-surface-900/70">
-            <p class="text-xs font-semibold uppercase tracking-[0.28em] text-primary-400/80">{$t('app.page_index')}</p>
-            <p class="mt-2 text-2xl font-semibold text-surface-900 dark:text-surface-50">{filteredSongs.length} / {availableSongs.length}</p>
-          </div>
-          <div class="rounded-2xl border border-primary-500/10 bg-white/80 p-4 text-sm shadow-sm dark:border-surface-700/40 dark:bg-surface-900/70">
-            <p class="text-xs font-semibold uppercase tracking-[0.28em] text-primary-400/80">{$t('app.toggle_favourites')}</p>
-            <p class="mt-2 text-2xl font-semibold text-surface-900 dark:text-surface-50">{favouriteSongs.length}</p>
-          </div>
-          <div class="rounded-2xl border border-primary-500/10 bg-white/80 p-4 text-sm shadow-sm dark:border-surface-700/40 dark:bg-surface-900/70">
-            <p class="text-xs font-semibold uppercase tracking-[0.28em] text-primary-400/80">{$t('app.view_song')}</p>
-            <p class="mt-2 text-2xl font-semibold text-surface-900 dark:text-surface-50">{$viewMode === 'basic' ? $t('app.view.basic') : $t('app.view.chords')}</p>
-          </div>
-        </div>
-      </div>
-      <div id="songbook-search" class="space-y-3 rounded-2xl border border-primary-500/15 bg-white/85 p-6 shadow-inner dark:border-surface-700/40 dark:bg-surface-900/70">
-        <label class="text-xs font-semibold uppercase tracking-[0.28em] text-surface-500 dark:text-surface-400" for="song-search">
-          {$t('app.search_placeholder')}
-        </label>
-        <div class="flex items-center gap-3 rounded-full border border-primary-500/20 bg-white/95 px-4 py-3 shadow-sm dark:border-surface-700/40 dark:bg-surface-800/80">
-          <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-primary-500/10 text-primary-500">
-            <Search class="h-5 w-5" />
-          </span>
-          <input
-            id="song-search"
-            class="w-full bg-transparent text-base text-surface-700 outline-none placeholder:text-surface-400 dark:text-surface-100"
-            type="search"
-            placeholder={$t('app.search_placeholder')}
-            bind:value={query}
-            bind:this={searchRef}
-          />
-          {#if query}
-            <button
-              class="text-xs font-semibold uppercase tracking-[0.28em] text-primary-500 transition hover:text-primary-400"
-              on:click={() => (query = '')}
-              type="button"
-            >
-              {$t('app.clear_query')}
-            </button>
-          {/if}
-        </div>
-        <p class="text-xs text-surface-500 dark:text-surface-300">{$t('app.search_hint')}</p>
-      </div>
-    </div>
-  </div>
-
-  <div class="grid gap-12 lg:grid-cols-[320px,1fr]">
-    <aside class="space-y-4 lg:space-y-6" use:fadeSlide={{ axis: 'y', from: 30 }}>
-      <button
-        class="flex w-full items-center justify-between rounded-full border border-primary-500/20 bg-white/80 px-5 py-3 text-sm font-semibold text-surface-700 transition hover:shadow-lg dark:border-surface-700/40 dark:bg-surface-900/80 dark:text-surface-100 lg:hidden"
-        on:click={() => (filtersOpen = !filtersOpen)}
-        aria-expanded={filtersOpen}
-        aria-controls="songbook-filters"
-        type="button"
+<section class="space-y-8 pb-16">
+  <div
+    class="space-y-6 rounded-2xl border border-surface-200/70 bg-white/80 p-6 shadow-sm dark:border-surface-800/60 dark:bg-surface-900/70"
+    use:fadeSlide
+  >
+    <div class="space-y-2">
+      <label
+        class="text-xs font-semibold uppercase tracking-[0.28em] text-surface-500 dark:text-surface-400"
+        for="song-search"
       >
-        <span class="inline-flex items-center gap-2">
-          <Filter class="h-4 w-4" />
-          {$t('app.page_index')}
-        </span>
-        <span class="inline-flex h-7 w-7 items-center justify-center rounded-full bg-primary-500/10 text-primary-500">
-          {#if filtersOpen}
-            <ChevronUp class="h-4 w-4" />
-          {:else}
-            <ChevronDown class="h-4 w-4" />
-          {/if}
-        </span>
-      </button>
-
-      <div
-        id="songbook-filters"
-        class="space-y-6 rounded-[2rem] border border-primary-500/20 bg-white/80 p-6 shadow-xl backdrop-blur-xl dark:border-surface-700/40 dark:bg-surface-900/80"
-        class:hidden={!filtersOpen && !isDesktop}
-      >
-        <div class="flex items-center justify-between">
-          <h3 class="text-lg font-semibold text-surface-800 dark:text-surface-50">{$t('app.page_index')}</h3>
+        {$t('app.search_placeholder')}
+      </label>
+      <div class="flex items-center gap-3 rounded-xl border border-surface-200/70 bg-white px-4 py-3 shadow-inner dark:border-surface-800/60 dark:bg-surface-900/80">
+        <Search class="h-4 w-4 text-primary-500" />
+        <input
+          id="song-search"
+          class="w-full bg-transparent text-base text-surface-800 outline-none placeholder:text-surface-400 dark:text-surface-100"
+          type="search"
+          placeholder={$t('app.search_placeholder')}
+          bind:value={query}
+          bind:this={searchRef}
+        />
+        {#if query}
           <button
-            class="text-xs font-semibold uppercase tracking-[0.3em] text-primary-500 transition hover:text-primary-400"
-            on:click={handleClearFilters}
+            class="text-xs font-semibold uppercase tracking-[0.28em] text-primary-500 transition hover:text-primary-400"
+            on:click={() => (query = '')}
             type="button"
           >
-            {$t('app.reset_filters')}
+            {$t('app.clear_query')}
           </button>
-        </div>
-
-        <div class="rounded-2xl border border-primary-500/15 bg-white/65 p-4 shadow-inner dark:border-surface-700/40 dark:bg-surface-800/70">
-          <p class="text-xs font-semibold uppercase tracking-[0.28em] text-primary-400/80">
-            {$t('app.filters.active')}
-          </p>
-          {#if filterBadges.length}
-            <div class="mt-3 flex flex-wrap gap-2">
-              {#each filterBadges as badge}
-                <span class="inline-flex items-center gap-2 rounded-full bg-primary-500/10 px-3 py-1 text-xs font-semibold text-primary-500">
-                  {badge}
-                </span>
-              {/each}
-            </div>
-          {:else}
-            <p class="mt-3 text-xs text-surface-500 dark:text-surface-300">{$t('app.filters.none')}</p>
-          {/if}
-        </div>
-
-        <div class="rounded-2xl border border-primary-500/15 bg-white/65 p-4 shadow-inner dark:border-surface-700/40 dark:bg-surface-800/70">
-          <label
-            class="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.28em] text-surface-500 dark:text-surface-400"
-            for="page-search"
-          >
-            {$t('app.page_search.label')}
-            <span class="text-[10px] normal-case tracking-normal text-surface-400 dark:text-surface-500">
-              {$t('app.page_search.hint')}
-            </span>
-          </label>
-          <div class="flex items-center gap-2 rounded-full border border-primary-500/15 bg-white/70 px-4 py-2 text-sm shadow-inner dark:border-surface-700/50 dark:bg-surface-900/60">
-            <MapPinned class="h-4 w-4 text-primary-500" />
-            <input
-              id="page-search"
-              class="w-full bg-transparent text-sm text-surface-700 placeholder:text-surface-400 focus:outline-none dark:text-surface-100"
-              type="text"
-              inputmode="numeric"
-              pattern="[0-9]*"
-              placeholder={$t('app.page_search.placeholder')}
-              bind:value={pageSearch}
-            />
-            {#if pageSearch.trim()}
-              <button
-                class="text-xs font-semibold uppercase tracking-[0.28em] text-primary-500 transition hover:text-primary-400"
-                on:click={() => (pageSearch = '')}
-                type="button"
-              >
-                {$t('app.clear_query')}
-              </button>
-            {/if}
-          </div>
-        </div>
-
-        <div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-1">
-          <button
-            class={`inline-flex items-center justify-center gap-2 rounded-full px-5 py-2 text-sm font-semibold transition ${
-              menuView === 'index'
-                ? 'bg-gradient-to-r from-primary-500 to-secondary-400 text-white shadow-lg'
-                : 'border border-primary-500/25 bg-white/70 text-surface-600 dark:border-surface-700/40 dark:bg-surface-800/60 dark:text-surface-200'
-            }`}
-            on:click={() => (menuView = 'index')}
-            type="button"
-          >
-            <LayoutList class="h-4 w-4" />
-            {$t('app.toggle_index')}
-          </button>
-          <button
-            class={`inline-flex items-center justify-center gap-2 rounded-full px-5 py-2 text-sm font-semibold transition ${
-              menuView === 'favourites'
-                ? 'bg-gradient-to-r from-primary-500 to-secondary-400 text-white shadow-lg'
-                : 'border border-primary-500/25 bg-white/70 text-surface-600 dark:border-surface-700/40 dark:bg-surface-800/60 dark:text-surface-200'
-            }`}
-            on:click={() => (menuView = 'favourites')}
-            type="button"
-          >
-            <Heart class="h-4 w-4" />
-            {$t('app.toggle_favourites')}
-          </button>
-        </div>
-
-        {#if menuView === 'favourites'}
-          {#if favouriteSongs.length === 0}
-            <p class="rounded-2xl border border-primary-500/15 bg-white/60 p-4 text-sm text-surface-500 dark:border-surface-700/30 dark:bg-surface-800/70 dark:text-surface-300">
-              {$t('app.no_favourites')}
-            </p>
-          {:else}
-            <ul class="space-y-3 text-sm">
-              {#each favouriteSongs as favSong (favSong.id + '-' + favSong.language)}
-                <li class="overflow-hidden rounded-2xl border border-primary-500/15 bg-white/70 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg dark:border-surface-700/40 dark:bg-surface-800/70">
-                  <button class="flex w-full flex-col items-start gap-1 px-4 py-3 text-left" on:click={() => openSong(favSong)} type="button">
-                    <p class="text-base font-semibold text-surface-800 dark:text-surface-100">{favSong.title}</p>
-                    <p class="text-xs uppercase tracking-[0.3em] text-primary-400/80">
-                      {$t('app.page_label')} {favSong.page}
-                    </p>
-                  </button>
-                </li>
-              {/each}
-            </ul>
-          {/if}
-        {:else}
-          <div class="space-y-3">
-            {#each pageGroups as group (group.label)}
-              {@const visiblePages = pagesForGroup(group)}
-              <div class="overflow-hidden rounded-2xl border border-primary-500/15 bg-white/70 dark:border-surface-700/40 dark:bg-surface-800/70">
-                <button
-                  class="flex w-full items-center justify-between gap-3 px-5 py-3 text-sm font-semibold text-surface-700 transition hover:text-primary-500 dark:text-surface-200"
-                  type="button"
-                  on:click={() => toggleGroup(group.label)}
-                  aria-expanded={openGroup === group.label}
-                  aria-controls={`page-group-${group.label}`}
-                >
-                  <span class="inline-flex items-center gap-2">
-                    <MapPinned class="h-4 w-4 text-primary-500" />
-                    {group.label}
-                  </span>
-                  <span class="rounded-full bg-primary-500/10 px-3 py-1 text-xs font-semibold text-primary-500">
-                    {visiblePages.length}
-                  </span>
-                </button>
-                <div
-                  id={`page-group-${group.label}`}
-                  class={`border-t border-primary-500/10 bg-white/60 transition-[max-height,opacity] duration-200 ease-out dark:border-surface-700/40 dark:bg-surface-900/60 ${
-                    openGroup === group.label ? 'block opacity-100' : 'hidden opacity-0'
-                  }`}
-                  role="region"
-                  aria-live="polite"
-                >
-                  {#if visiblePages.length}
-                    <div class="flex flex-wrap gap-2 px-5 py-4">
-                      {#each visiblePages as pageNumber}
-                        <button
-                          class={`group inline-flex items-center gap-2 rounded-full border px-4 py-2 text-xs font-semibold transition ${
-                            pageFilter === pageNumber
-                              ? 'border-transparent bg-gradient-to-r from-primary-500 to-secondary-400 text-white shadow-lg'
-                              : 'border-primary-500/20 bg-white/70 text-surface-600 hover:border-primary-400 hover:text-primary-500 dark:border-surface-700/40 dark:bg-surface-900/50 dark:text-surface-200'
-                          }`}
-                          type="button"
-                          on:click={() => handlePageSelect(pageNumber)}
-                        >
-                          <span>{$t('app.page_label')} {pageNumber}</span>
-                          <span class={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${
-                            pageFilter === pageNumber
-                              ? 'bg-white/20 text-white'
-                              : 'bg-primary-500/10 text-primary-500'
-                          }`}>
-                            {(groupedByPage[pageNumber] ?? []).length}
-                          </span>
-                        </button>
-                      {/each}
-                    </div>
-                  {:else}
-                    <p class="px-5 py-4 text-xs text-surface-500 dark:text-surface-300">{$t('app.filters.no_page_results')}</p>
-                  {/if}
-                </div>
-              </div>
-            {/each}
-          </div>
         {/if}
       </div>
-    </aside>
+      <p class="text-xs text-surface-500 dark:text-surface-400">{$t('app.search_hint')}</p>
+    </div>
 
-    <section class="space-y-6" use:fadeSlide={{ axis: 'y', from: 30, delay: 0.05 }}>
-      <div class="space-y-4 rounded-3xl border border-primary-500/20 bg-white/80 px-5 py-5 text-sm shadow-lg backdrop-blur-xl dark:border-surface-700/40 dark:bg-surface-900/80">
-        <div class="flex flex-wrap items-center justify-between gap-4 text-surface-500 dark:text-surface-300">
-          <div class="flex items-center gap-3">
-            <span class="text-lg font-semibold text-surface-800 dark:text-surface-100">{filteredSongs.length}</span>
-            <span>/</span>
-            <span>{availableSongs.length}</span>
-            {#if pageFilter}
-              <span class="rounded-full bg-primary-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-primary-500">
-                {$t('app.page_label')} {pageFilter}
-              </span>
-            {/if}
-          </div>
-          {#if filterBadges.length}
-            <div class="flex flex-wrap items-center gap-2">
-              {#each filterBadges.slice(0, 2) as badge, badgeIndex}
-                <span class="rounded-full bg-primary-500/10 px-3 py-1 text-xs font-semibold text-primary-500">{badge}</span>
-                {#if badgeIndex === 1 && filterBadges.length > 2}
-                  <span class="rounded-full bg-white/70 px-3 py-1 text-xs font-semibold text-surface-500 dark:bg-surface-800/70 dark:text-surface-200">
-                    +{filterBadges.length - 2}
-                  </span>
-                {/if}
-              {/each}
-            </div>
-          {/if}
-        </div>
-        <div class="flex flex-wrap items-center justify-between gap-3">
-          <div
-            class="flex flex-wrap gap-2"
-            role="tablist"
-            aria-label={$t('app.view_song')}
-          >
-            <button
-              class={`inline-flex items-center justify-center gap-2 rounded-full px-5 py-2 text-sm font-semibold transition ${
-                $viewMode === 'basic'
-                  ? 'bg-gradient-to-r from-primary-500 to-secondary-400 text-white shadow-lg'
-                  : 'border border-primary-500/20 bg-white/70 text-surface-600 dark:border-surface-700/40 dark:bg-surface-800/70 dark:text-surface-200'
-              }`}
-              type="button"
-              role="tab"
-              aria-selected={$viewMode === 'basic'}
-              tabindex={$viewMode === 'basic' ? 0 : -1}
-              on:click={() => viewMode.set('basic')}
-              on:keydown={(event) => handleViewTabKeydown(event, 'basic')}
-            >
-              {$t('app.view.basic')}
-            </button>
-            <button
-              class={`inline-flex items-center justify-center gap-2 rounded-full px-5 py-2 text-sm font-semibold transition ${
-                $viewMode === 'chords'
-                  ? 'bg-gradient-to-r from-primary-500 to-secondary-400 text-white shadow-lg'
-                  : 'border border-primary-500/20 bg-white/70 text-surface-600 dark:border-surface-700/40 dark:bg-surface-800/70 dark:text-surface-200'
-              }`}
-              type="button"
-              role="tab"
-              aria-selected={$viewMode === 'chords'}
-              tabindex={$viewMode === 'chords' ? 0 : -1}
-              on:click={() => viewMode.set('chords')}
-              on:keydown={(event) => handleViewTabKeydown(event, 'chords')}
-            >
-              {$t('app.view.chords')}
-            </button>
-          </div>
-          <div class="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-surface-500 dark:text-surface-300">
-            <span>{$t('app.sort.label')}</span>
-            {#each sortOptions as option}
-              <button
-                class={`inline-flex items-center justify-center gap-2 rounded-full px-4 py-2 text-[11px] font-semibold normal-case tracking-normal transition ${
-                  sortMode === option.value
-                    ? 'bg-gradient-to-r from-primary-500 to-secondary-400 text-white shadow-lg'
-                    : 'border border-primary-500/20 bg-white/70 text-surface-600 dark:border-surface-700/40 dark:bg-surface-800/70 dark:text-surface-200'
-                }`}
-                aria-pressed={sortMode === option.value}
-                on:click={() => (sortMode = option.value)}
-                type="button"
-              >
-                <span class="inline-flex items-center gap-2 text-sm">
-                  <svelte:component this={option.icon} class="h-4 w-4" />
-                  <span>{$t(option.label)}</span>
-                </span>
-              </button>
-            {/each}
-          </div>
-        </div>
-      </div>
-
-      {#if filteredSongs.length === 0}
-        <div class="rounded-[2rem] border border-primary-500/15 bg-white/70 px-8 py-12 text-center text-sm text-surface-500 shadow-inner dark:border-surface-700/40 dark:bg-surface-900/80 dark:text-surface-300">
-          {$t('app.empty_state')}
-        </div>
-      {:else}
-        <div class="space-y-6">
-          {#each filteredSongs as song, index (song.id + '-' + song.language)}
-            <SongCard
-              {song}
-              {index}
-              viewMode={activeViewMode}
-              isFavourite={$favourites.includes(`${song.id}-${song.language}`)}
-              on:open={(event) => openSong(event.detail)}
-              on:toggleFavourite={(event) => toggleFavourite(event.detail)}
-            />
-          {/each}
-        </div>
+    <div class="flex flex-wrap items-center gap-3 text-sm text-surface-600 dark:text-surface-300">
+      <span class="font-semibold text-surface-900 dark:text-surface-50">{filteredSongs.length}</span>
+      <span>/</span>
+      <span>{availableSongs.length}</span>
+      {#if pageFilter}
+        <span class="rounded-full bg-primary-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-primary-500">
+          {$t('app.page_label')} {pageFilter}
+        </span>
       {/if}
-    </section>
-  </div>
-</section>
+    </div>
 
-<section class="relative mt-16 overflow-hidden rounded-[2.75rem] border border-primary-500/20 bg-gradient-to-br from-primary-500/10 via-white/80 to-secondary-400/10 px-6 py-12 shadow-2xl backdrop-blur-xl dark:border-surface-700/40 dark:from-primary-500/15 dark:via-surface-900/90 dark:to-secondary-500/10 sm:px-12" use:fadeSlide={{ axis: 'y', from: 40, delay: 0.08 }}>
-  <div class="pointer-events-none absolute inset-0 -z-10">
-    <div class="absolute -left-24 top-0 h-64 w-64 rounded-full bg-primary-500/20 blur-[140px]"></div>
-    <div class="absolute bottom-0 right-0 h-72 w-72 rounded-full bg-secondary-400/25 blur-[160px]"></div>
+    {#if filterBadges.length}
+      <div class="flex flex-wrap gap-2">
+        {#each filterBadges as badge}
+          <span class="inline-flex items-center gap-2 rounded-full border border-primary-200/60 bg-primary-50 px-3 py-1 text-xs font-semibold text-primary-600 dark:border-primary-500/40 dark:bg-primary-500/10 dark:text-primary-300">
+            {badge}
+          </span>
+        {/each}
+      </div>
+    {/if}
   </div>
-  <div class="mx-auto flex max-w-3xl flex-col items-center gap-6 text-center">
-    <span class="inline-flex items-center gap-2 rounded-full bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.32em] text-primary-500 dark:bg-surface-800/80">
-      <Sparkles class="h-4 w-4" />
-      {$t('app.brand_global')}
-    </span>
-    <h3 class="text-balance text-3xl font-semibold text-surface-900 dark:text-surface-50 sm:text-4xl">
-      {$t('app.cta.title')}
-    </h3>
-    <p class="max-w-2xl text-base text-surface-600 dark:text-surface-300">
-      {$t('app.cta.subtitle')}
-    </p>
-    <div class="flex flex-wrap justify-center gap-3">
+
+  <div
+    class="space-y-6 rounded-2xl border border-surface-200/70 bg-white/80 p-6 shadow-sm dark:border-surface-800/60 dark:bg-surface-900/70"
+    use:fadeSlide={{ axis: 'y', from: 30, delay: 0.05 }}
+  >
+    <div class="flex flex-wrap gap-2">
       <button
-        class="inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-primary-500 to-secondary-400 px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:shadow-xl"
-        on:click={focusSearchInput}
+        class={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition ${
+          menuView === 'index'
+            ? 'bg-primary-500 text-white shadow-sm'
+            : 'border border-surface-200/70 bg-white text-surface-600 hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200'
+        }`}
+        on:click={() => (menuView = 'index')}
         type="button"
       >
         <LayoutList class="h-4 w-4" />
-        {$t('app.cta.primary')}
+        {$t('app.toggle_index')}
       </button>
       <button
-        class="inline-flex items-center justify-center gap-2 rounded-full border border-primary-500/25 bg-white/80 px-6 py-3 text-sm font-semibold text-surface-600 transition hover:-translate-y-0.5 hover:border-primary-500 hover:text-primary-500 dark:border-surface-700/40 dark:bg-surface-900/80 dark:text-surface-200"
-        on:click={openFavouritesQuickly}
+        class={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition ${
+          menuView === 'favourites'
+            ? 'bg-primary-500 text-white shadow-sm'
+            : 'border border-surface-200/70 bg-white text-surface-600 hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200'
+        }`}
+        on:click={() => (menuView = 'favourites')}
         type="button"
       >
         <Heart class="h-4 w-4" />
-        {$t('app.cta.secondary')}
+        {$t('app.toggle_favourites')}
+      </button>
+      <button
+        class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-surface-500 transition hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-300"
+        on:click={handleClearFilters}
+        type="button"
+      >
+        {$t('app.reset_filters')}
       </button>
     </div>
+
+    <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+      <div class="flex items-center gap-2" role="tablist" aria-label={$t('app.view_song')}>
+        <button
+          class={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+            $viewMode === 'basic'
+              ? 'bg-surface-900 text-white dark:bg-surface-50 dark:text-surface-900'
+              : 'border border-surface-200/70 bg-white text-surface-600 hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200'
+          }`}
+          type="button"
+          role="tab"
+          aria-selected={$viewMode === 'basic'}
+          tabindex={$viewMode === 'basic' ? 0 : -1}
+          on:click={() => viewMode.set('basic')}
+          on:keydown={(event) => handleViewTabKeydown(event, 'basic')}
+        >
+          {$t('app.view.basic')}
+        </button>
+        <button
+          class={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+            $viewMode === 'chords'
+              ? 'bg-surface-900 text-white dark:bg-surface-50 dark:text-surface-900'
+              : 'border border-surface-200/70 bg-white text-surface-600 hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200'
+          }`}
+          type="button"
+          role="tab"
+          aria-selected={$viewMode === 'chords'}
+          tabindex={$viewMode === 'chords' ? 0 : -1}
+          on:click={() => viewMode.set('chords')}
+          on:keydown={(event) => handleViewTabKeydown(event, 'chords')}
+        >
+          {$t('app.view.chords')}
+        </button>
+      </div>
+      <label class="flex items-center gap-3 text-sm font-medium text-surface-600 dark:text-surface-300">
+        <span class="text-xs font-semibold uppercase tracking-[0.3em] text-surface-500 dark:text-surface-400">
+          {$t('app.sort.label')}
+        </span>
+        <select
+          class="rounded-full border border-surface-200/70 bg-white px-3 py-2 text-sm font-semibold text-surface-700 outline-none dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-100"
+          bind:value={sortMode}
+        >
+          {#each sortOptions as option}
+            <option value={option.value}>{$t(option.label)}</option>
+          {/each}
+        </select>
+      </label>
+    </div>
+
+    <div class="space-y-4">
+      <div class="space-y-2">
+        <label
+          class="text-xs font-semibold uppercase tracking-[0.28em] text-surface-500 dark:text-surface-400"
+          for="page-search"
+        >
+          {$t('app.page_search.label')}
+        </label>
+        <input
+          id="page-search"
+          class="w-full rounded-xl border border-surface-200/70 bg-white px-3 py-2 text-sm text-surface-700 outline-none placeholder:text-surface-400 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-100"
+          type="text"
+          inputmode="numeric"
+          pattern="[0-9]*"
+          placeholder={$t('app.page_search.placeholder')}
+          bind:value={pageSearch}
+        />
+      </div>
+
+      {#if menuView === 'favourites'}
+        {#if favouriteSongs.length === 0}
+          <p class="rounded-xl border border-surface-200/70 bg-white px-4 py-4 text-sm text-surface-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-300">
+            {$t('app.no_favourites')}
+          </p>
+        {:else}
+          <ul class="grid gap-3 sm:grid-cols-2">
+            {#each favouriteSongs as favSong (favSong.id + '-' + favSong.language)}
+              <li>
+                <button
+                  class="w-full rounded-xl border border-surface-200/70 bg-white px-4 py-3 text-left text-sm font-semibold text-surface-700 transition hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200"
+                  on:click={() => openSong(favSong)}
+                  type="button"
+                >
+                  <span class="block text-base font-semibold text-surface-900 dark:text-surface-50">{favSong.title}</span>
+                  <span class="text-xs uppercase tracking-[0.28em] text-surface-500 dark:text-surface-400">
+                    {$t('app.page_label')} {favSong.page}
+                  </span>
+                </button>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      {:else}
+        <div class="space-y-4">
+          {#each pageGroups as group (group.label)}
+            {@const pages = pagesForGroup(group)}
+            {#if pages.length}
+              <div class="space-y-2">
+                <p class="text-xs font-semibold uppercase tracking-[0.28em] text-surface-500 dark:text-surface-400">{group.label}</p>
+                <div class="flex flex-wrap gap-2">
+                  {#each pages as pageNumber}
+                    <button
+                      class={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
+                        pageFilter === pageNumber
+                          ? 'border-transparent bg-primary-500 text-white shadow-sm'
+                          : 'border-surface-200/70 bg-white text-surface-600 hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200'
+                      }`}
+                      type="button"
+                      on:click={() => handlePageSelect(pageNumber)}
+                    >
+                      <span>{$t('app.page_label')} {pageNumber}</span>
+                      <span
+                        class={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${
+                          pageFilter === pageNumber ? 'bg-white/30 text-white' : 'bg-primary-500/10 text-primary-500'
+                        }`}
+                      >
+                        {(groupedByPage[pageNumber] ?? []).length}
+                      </span>
+                    </button>
+                  {/each}
+                </div>
+              </div>
+            {/if}
+          {/each}
+        </div>
+      {/if}
+    </div>
   </div>
+
+  {#if filteredSongs.length === 0}
+    <div class="rounded-2xl border border-dashed border-surface-200/70 bg-white/70 px-6 py-12 text-center text-sm text-surface-500 dark:border-surface-700 dark:bg-surface-900/70 dark:text-surface-300">
+      {$t('app.empty_state')}
+    </div>
+  {:else}
+    <div class="space-y-4" use:fadeSlide={{ axis: 'y', from: 20, delay: 0.08 }}>
+      {#each filteredSongs as song, index (song.id + '-' + song.language)}
+        <SongCard
+          {song}
+          {index}
+          viewMode={activeViewMode}
+          isFavourite={$favourites.includes(`${song.id}-${song.language}`)}
+          on:open={(event) => openSong(event.detail)}
+          on:toggleFavourite={(event) => toggleFavourite(event.detail)}
+        />
+      {/each}
+    </div>
+  {/if}
 </section>
+
+{#if showScrollTop}
+  <button
+    class="fixed bottom-6 right-5 z-40 inline-flex items-center gap-2 rounded-full bg-primary-500 px-4 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-primary-600"
+    on:click={scrollToTop}
+    type="button"
+  >
+    <ArrowUp class="h-4 w-4" />
+    <span>Up to top</span>
+  </button>
+{/if}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,4 +1,4 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
@@ -11,8 +11,10 @@ const config = {
 		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
 		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
-		adapter: adapter()
-	}
+                adapter: adapter({
+                        fallback: '200.html'
+                })
+        }
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- switch to the static adapter to satisfy deployment requirements
- refresh the home/song list layout with a streamlined, mobile-first design and an "Up to top" shortcut
- add a persisted light/dark theme toggle and simplify song cards with updated styling

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68da57e119f8832786c3d9d4dc11cfa7