### PR TITLE
Add theme presets and refine mobile layouts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -500,6 +500,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
 			"integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@eslint/object-schema": "^2.1.6",
 				"debug": "^4.3.1",
@@ -514,6 +515,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
 			"integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
@@ -536,6 +538,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
 			"integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -559,6 +562,7 @@
 			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
 			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -583,6 +587,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
 			"integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
@@ -592,6 +597,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
 			"integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@eslint/core": "^0.15.2",
 				"levn": "^0.4.1"
@@ -605,6 +611,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
 			"integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.15"
 			},
@@ -668,6 +675,7 @@
 			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
 			"integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=18.18.0"
 			}
@@ -677,6 +685,7 @@
 			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
 			"integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@humanfs/core": "^0.19.1",
 				"@humanwhocodes/retry": "^0.4.0"
@@ -690,6 +699,7 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
 			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=12.22"
 			},
@@ -703,6 +713,7 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
 			"integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=18.18"
 			},
@@ -1248,7 +1259,6 @@
 			"integrity": "sha512-44Mm5csR4mesKx2Eyhtk8UVrLJ4c04BT2wMTfYGKJMOkUqpHP5KLL2DPV0hXUA4t4+T3ZYe0aBygd42lVYv2cA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
@@ -1288,7 +1298,6 @@
 			"integrity": "sha512-Txsm1tJvtiYeLUVRNqxZGKR/mI+CzuIQuc2gn+YCs9rMTowpNZ2Nqt53JdL8KF9bLhAf2ruR/dr9eZCwdTriRA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^2.1.0",
 				"debug": "^4.3.4",
@@ -1734,7 +1743,6 @@
 			"integrity": "sha512-EHrrEsyhOhxYt8MTg4zTF+DJMuNBzWwgvvOYNj/zm1vnaD/IC5zCXFehZv94Piqa2cRFfXrTFxIvO95L7Qc/cw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.44.1",
 				"@typescript-eslint/types": "8.44.1",
@@ -1970,7 +1978,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1992,6 +1999,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -2008,6 +2016,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -2022,7 +2031,8 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"license": "Python-2.0"
+			"license": "Python-2.0",
+			"peer": true
 		},
 		"node_modules/aria-query": {
 			"version": "5.3.2",
@@ -2101,6 +2111,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
 			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -2139,7 +2150,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.3",
 				"caniuse-lite": "^1.0.30001741",
@@ -2159,6 +2169,7 @@
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -2189,6 +2200,7 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -2269,6 +2281,7 @@
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -2280,13 +2293,15 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cookie": {
 			"version": "0.6.0",
@@ -2303,6 +2318,7 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
 			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -2377,7 +2393,8 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/deepmerge": {
 			"version": "4.3.1",
@@ -2531,6 +2548,7 @@
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -2665,6 +2683,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
 			"integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.15"
 			},
@@ -2716,6 +2735,7 @@
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
 			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
@@ -2785,7 +2805,8 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/fast-glob": {
 			"version": "3.3.3",
@@ -2821,13 +2842,15 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/fastq": {
 			"version": "1.19.1",
@@ -2862,6 +2885,7 @@
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
 			"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"flat-cache": "^4.0.0"
 			},
@@ -2887,6 +2911,7 @@
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -2903,6 +2928,7 @@
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
 			"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"flatted": "^3.2.9",
 				"keyv": "^4.5.4"
@@ -2915,7 +2941,8 @@
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
 			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/fraction.js": {
 			"version": "4.3.7",
@@ -2978,6 +3005,7 @@
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
 			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"is-glob": "^4.0.3"
 			},
@@ -3028,6 +3056,7 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -3043,6 +3072,7 @@
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
 			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -3052,6 +3082,7 @@
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
 			"integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
@@ -3068,6 +3099,7 @@
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.8.19"
 			}
@@ -3134,7 +3166,8 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/jiti": {
 			"version": "2.6.0",
@@ -3151,6 +3184,7 @@
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -3162,25 +3196,29 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
 			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
 			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"json-buffer": "3.0.1"
 			}
@@ -3232,6 +3270,7 @@
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
 			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
@@ -3499,6 +3538,7 @@
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"p-locate": "^5.0.0"
 			},
@@ -3513,7 +3553,8 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/lru-queue": {
 			"version": "0.1.0",
@@ -3609,6 +3650,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -3739,6 +3781,7 @@
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
 			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
@@ -3756,6 +3799,7 @@
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
 			},
@@ -3771,6 +3815,7 @@
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
@@ -3786,6 +3831,7 @@
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"callsites": "^3.0.0"
 			},
@@ -3798,6 +3844,7 @@
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -3807,6 +3854,7 @@
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -3847,7 +3895,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -3981,6 +4028,7 @@
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 0.8.0"
 			}
@@ -3991,7 +4039,6 @@
 			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -4018,6 +4065,7 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -4062,6 +4110,7 @@
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -4179,6 +4228,7 @@
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
 			},
@@ -4191,6 +4241,7 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -4224,6 +4275,7 @@
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -4236,6 +4288,7 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -4248,7 +4301,6 @@
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.20.tgz",
 			"integrity": "sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.15",
@@ -4368,8 +4420,7 @@
 			"version": "4.1.13",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
 			"integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/tapable": {
 			"version": "2.2.3",
@@ -4484,6 +4535,7 @@
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
 			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1"
 			},
@@ -4497,7 +4549,6 @@
 			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -4572,6 +4623,7 @@
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
@@ -4602,7 +4654,6 @@
 			"integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.21.3",
 				"postcss": "^8.4.43",
@@ -5136,6 +5187,7 @@
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"isexe": "^2.0.0"
 			},
@@ -5151,6 +5203,7 @@
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
 			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -5200,6 +5253,7 @@
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},

--- a/src/app.css
+++ b/src/app.css
@@ -4,10 +4,170 @@
 @layer base {
   :root {
     color-scheme: light;
+    --color-primary-50: 238 242 255;
+    --color-primary-100: 224 231 255;
+    --color-primary-200: 199 210 254;
+    --color-primary-300: 165 180 252;
+    --color-primary-400: 129 140 248;
+    --color-primary-500: 99 102 241;
+    --color-primary-600: 79 70 229;
+    --color-primary-700: 67 56 202;
+    --color-primary-800: 55 48 163;
+    --color-primary-900: 49 46 129;
+    --color-secondary-50: 236 254 255;
+    --color-secondary-100: 207 250 254;
+    --color-secondary-200: 165 243 252;
+    --color-secondary-300: 103 232 249;
+    --color-secondary-400: 34 211 238;
+    --color-secondary-500: 14 165 233;
+    --color-secondary-600: 8 145 178;
+    --color-secondary-700: 14 116 144;
+    --color-secondary-800: 21 94 117;
+    --color-secondary-900: 22 78 99;
+    --color-surface-50: 244 247 255;
+    --color-surface-100: 235 240 255;
+    --color-surface-200: 221 229 254;
+    --color-surface-300: 196 210 252;
+    --color-surface-400: 165 180 252;
+    --color-surface-500: 129 140 248;
+    --color-surface-600: 99 102 241;
+    --color-surface-700: 79 70 229;
+    --color-surface-800: 67 56 202;
+    --color-surface-900: 55 48 163;
   }
 
   :root[data-theme='dark'] {
     color-scheme: dark;
+    --color-primary-50: 224 231 255;
+    --color-primary-100: 203 213 225;
+    --color-primary-200: 191 219 254;
+    --color-primary-300: 147 197 253;
+    --color-primary-400: 96 165 250;
+    --color-primary-500: 59 130 246;
+    --color-primary-600: 37 99 235;
+    --color-primary-700: 29 78 216;
+    --color-primary-800: 30 64 175;
+    --color-primary-900: 30 58 138;
+    --color-secondary-50: 240 253 250;
+    --color-secondary-100: 204 251 241;
+    --color-secondary-200: 153 246 228;
+    --color-secondary-300: 110 231 183;
+    --color-secondary-400: 52 211 153;
+    --color-secondary-500: 16 185 129;
+    --color-secondary-600: 5 150 105;
+    --color-secondary-700: 4 120 87;
+    --color-secondary-800: 6 95 70;
+    --color-secondary-900: 6 78 59;
+    --color-surface-50: 17 24 39;
+    --color-surface-100: 15 23 42;
+    --color-surface-200: 30 41 59;
+    --color-surface-300: 55 65 81;
+    --color-surface-400: 75 85 99;
+    --color-surface-500: 96 106 123;
+    --color-surface-600: 107 114 128;
+    --color-surface-700: 148 163 184;
+    --color-surface-800: 203 213 225;
+    --color-surface-900: 226 232 240;
+  }
+
+  :root[data-theme='sunset'] {
+    --color-primary-50: 255 247 237;
+    --color-primary-100: 255 237 213;
+    --color-primary-200: 254 215 170;
+    --color-primary-300: 253 186 116;
+    --color-primary-400: 251 146 60;
+    --color-primary-500: 249 115 22;
+    --color-primary-600: 234 88 12;
+    --color-primary-700: 194 65 12;
+    --color-primary-800: 154 52 18;
+    --color-primary-900: 124 45 18;
+    --color-secondary-50: 255 241 242;
+    --color-secondary-100: 255 228 230;
+    --color-secondary-200: 254 205 211;
+    --color-secondary-300: 253 164 175;
+    --color-secondary-400: 251 113 133;
+    --color-secondary-500: 244 63 94;
+    --color-secondary-600: 225 29 72;
+    --color-secondary-700: 190 24 60;
+    --color-secondary-800: 159 18 57;
+    --color-secondary-900: 136 19 55;
+    --color-surface-50: 255 248 244;
+    --color-surface-100: 254 236 226;
+    --color-surface-200: 253 222 206;
+    --color-surface-300: 252 211 185;
+    --color-surface-400: 249 196 160;
+    --color-surface-500: 243 169 125;
+    --color-surface-600: 224 140 93;
+    --color-surface-700: 191 110 69;
+    --color-surface-800: 159 88 57;
+    --color-surface-900: 133 73 50;
+  }
+
+  :root[data-theme='forest'] {
+    color-scheme: dark;
+    --color-primary-50: 236 253 245;
+    --color-primary-100: 209 250 229;
+    --color-primary-200: 167 243 208;
+    --color-primary-300: 110 231 183;
+    --color-primary-400: 52 211 153;
+    --color-primary-500: 34 197 94;
+    --color-primary-600: 22 163 74;
+    --color-primary-700: 21 128 61;
+    --color-primary-800: 22 101 52;
+    --color-primary-900: 20 83 45;
+    --color-secondary-50: 236 254 255;
+    --color-secondary-100: 207 250 254;
+    --color-secondary-200: 165 243 252;
+    --color-secondary-300: 103 232 249;
+    --color-secondary-400: 34 211 238;
+    --color-secondary-500: 14 165 233;
+    --color-secondary-600: 8 145 178;
+    --color-secondary-700: 14 116 144;
+    --color-secondary-800: 21 94 117;
+    --color-secondary-900: 22 78 99;
+    --color-surface-50: 13 17 23;
+    --color-surface-100: 15 23 30;
+    --color-surface-200: 17 35 38;
+    --color-surface-300: 22 53 46;
+    --color-surface-400: 34 78 60;
+    --color-surface-500: 45 102 74;
+    --color-surface-600: 74 131 102;
+    --color-surface-700: 125 168 144;
+    --color-surface-800: 180 208 186;
+    --color-surface-900: 209 231 212;
+  }
+
+  :root[data-theme='ocean'] {
+    --color-primary-50: 236 254 255;
+    --color-primary-100: 207 250 254;
+    --color-primary-200: 165 243 252;
+    --color-primary-300: 103 232 249;
+    --color-primary-400: 34 211 238;
+    --color-primary-500: 14 165 233;
+    --color-primary-600: 8 145 178;
+    --color-primary-700: 14 116 144;
+    --color-primary-800: 21 94 117;
+    --color-primary-900: 22 78 99;
+    --color-secondary-50: 239 246 255;
+    --color-secondary-100: 219 234 254;
+    --color-secondary-200: 191 219 254;
+    --color-secondary-300: 147 197 253;
+    --color-secondary-400: 96 165 250;
+    --color-secondary-500: 59 130 246;
+    --color-secondary-600: 37 99 235;
+    --color-secondary-700: 29 78 216;
+    --color-secondary-800: 30 64 175;
+    --color-secondary-900: 30 58 138;
+    --color-surface-50: 240 249 255;
+    --color-surface-100: 224 242 254;
+    --color-surface-200: 186 230 253;
+    --color-surface-300: 145 215 250;
+    --color-surface-400: 103 197 241;
+    --color-surface-500: 59 172 227;
+    --color-surface-600: 34 139 199;
+    --color-surface-700: 30 112 168;
+    --color-surface-800: 31 89 141;
+    --color-surface-900: 30 73 117;
   }
 
   body {
@@ -28,8 +188,8 @@
   }
 
   ::selection {
-    background: rgba(99, 102, 241, 0.18);
-    color: rgb(18, 21, 56);
+    background: rgb(var(--color-primary-400) / 0.18);
+    color: rgb(var(--color-surface-900));
   }
 
   ::-webkit-scrollbar {

--- a/src/lib/components/layout/AppHeader.svelte
+++ b/src/lib/components/layout/AppHeader.svelte
@@ -1,22 +1,31 @@
 <script lang="ts">
   import { t } from 'svelte-i18n';
-  import { language, theme, toggleTheme } from '$lib/stores/preferences';
+  import { language, theme, themeOptions } from '$lib/stores/preferences';
   import { isSyncing, lastSynced } from '$lib/stores/songStore';
   import { derived } from 'svelte/store';
   import { Languages, Moon, Search, Sun } from 'lucide-svelte';
+  import type { ThemeName } from '$lib/stores/preferences';
 
   const syncStatus = derived(isSyncing, ($isSyncing) => ($isSyncing ? $t('app.syncing') : $t('app.brand_available_offline')));
+
+  function selectTheme(name: ThemeName) {
+    theme.set(name);
+  }
+
+  function themeMode(name: ThemeName) {
+    return themeOptions.find((option) => option.id === name)?.mode ?? 'light';
+  }
 </script>
 
-<section class="pt-10 sm:pt-12 lg:pt-14">
-  <div class="rounded-2xl border border-surface-200/70 bg-white/80 p-6 shadow-sm backdrop-blur dark:border-surface-800/60 dark:bg-surface-900/70 sm:p-8">
-    <div class="flex flex-col gap-6">
+<section class="pt-6 sm:pt-10 lg:pt-12">
+  <div class="rounded-xl border border-surface-200/70 bg-white/80 p-5 shadow-sm backdrop-blur dark:border-surface-800/60 dark:bg-surface-900/70 sm:rounded-2xl sm:p-7">
+    <div class="flex flex-col gap-5">
       <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div class="space-y-2">
-          <p class="text-xs font-semibold uppercase tracking-[0.3em] text-primary-500">
+          <p class="text-[11px] font-semibold uppercase tracking-[0.22em] text-primary-500">
             {$t('app.brand_global')}
           </p>
-          <h1 class="text-balance text-3xl font-semibold text-surface-900 dark:text-surface-50 sm:text-4xl">
+          <h1 class="text-balance text-2xl font-semibold text-surface-900 dark:text-surface-50 sm:text-3xl lg:text-4xl">
             {$t('app.title')}
           </h1>
           <p class="max-w-2xl text-sm leading-relaxed text-surface-600 dark:text-surface-300">
@@ -24,27 +33,40 @@
           </p>
         </div>
         <div class="flex flex-wrap items-center gap-2 sm:justify-end">
-          <button
-            class="inline-flex items-center gap-2 rounded-full border border-surface-200/80 bg-white px-4 py-2 text-sm font-semibold text-surface-700 shadow-sm transition hover:border-primary-400 hover:text-primary-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:border-surface-700 dark:bg-surface-800/90 dark:text-surface-200"
-            on:click={toggleTheme}
-            type="button"
-            aria-label={$theme === 'dark'
-              ? `${$t('app.theme_label')} – ${$t('app.theme.light')}`
-              : `${$t('app.theme_label')} – ${$t('app.theme.dark')}`}
-          >
-            {#if $theme === 'dark'}
-              <Sun class="h-4 w-4" />
-              <span class="text-xs font-semibold uppercase tracking-[0.2em]">{$t('app.theme.light') ?? 'Light'}</span>
+          <div class="flex flex-wrap items-center gap-1 rounded-full border border-surface-200/80 bg-white px-3 py-1.5 text-xs font-semibold text-surface-600 shadow-sm dark:border-surface-700 dark:bg-surface-800/90 dark:text-surface-200">
+            {#if themeMode($theme) === 'dark'}
+              <Moon class="h-4 w-4" aria-hidden="true" />
             {:else}
-              <Moon class="h-4 w-4" />
-              <span class="text-xs font-semibold uppercase tracking-[0.2em]">{$t('app.theme.dark') ?? 'Dark'}</span>
+              <Sun class="h-4 w-4" aria-hidden="true" />
             {/if}
-          </button>
-          <label class="inline-flex items-center gap-2 rounded-full border border-surface-200/80 bg-white px-4 py-2 text-sm font-semibold text-surface-700 shadow-sm transition hover:border-primary-400 focus-within:ring-2 focus-within:ring-primary-400 focus-within:ring-offset-2 focus-within:ring-offset-white dark:border-surface-700 dark:bg-surface-800/90 dark:text-surface-200 dark:focus-within:ring-offset-surface-900">
-            <Languages class="h-4 w-4 text-primary-500" />
-            <span class="text-xs font-semibold uppercase tracking-[0.2em] text-surface-500 dark:text-surface-400">
-              {$t('app.language_label')}
+            <span class="uppercase tracking-[0.18em] text-surface-500 dark:text-surface-400">
+              {$t('app.theme_label')}
             </span>
+            <div class="flex flex-wrap gap-1">
+              {#each themeOptions as option}
+                <button
+                  class={`inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 ${
+                    $theme === option.id
+                      ? 'border-primary-400 text-primary-600 dark:border-primary-500 dark:text-primary-300'
+                      : 'border-transparent text-surface-500 hover:text-primary-500 dark:text-surface-300'
+                  }`}
+                  type="button"
+                  on:click={() => selectTheme(option.id)}
+                  aria-label={$t(option.labelKey)}
+                >
+                  <span
+                    aria-hidden="true"
+                    class="h-2.5 w-6 rounded-full"
+                    style={`background: linear-gradient(90deg, ${option.swatch[0]}, ${option.swatch[1]});`}
+                  />
+                  <span class="hidden sm:inline">{$t(option.labelKey)}</span>
+                </button>
+              {/each}
+            </div>
+          </div>
+          <label class="inline-flex items-center gap-2 rounded-full border border-surface-200/80 bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-surface-600 shadow-sm transition hover:border-primary-400 focus-within:ring-2 focus-within:ring-primary-400 focus-within:ring-offset-2 focus-within:ring-offset-white dark:border-surface-700 dark:bg-surface-800/90 dark:text-surface-200 dark:focus-within:ring-offset-surface-900">
+            <Languages class="h-4 w-4 text-primary-500" />
+            <span class="hidden text-[11px] sm:inline">{$t('app.language_label')}</span>
             <select
               class="rounded-full border-none bg-transparent text-sm font-semibold text-surface-700 outline-none dark:text-surface-200"
               bind:value={$language}
@@ -57,18 +79,18 @@
       </div>
       <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <a
-          class="inline-flex items-center justify-center gap-2 rounded-full bg-primary-500 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          class="inline-flex items-center justify-center gap-2 rounded-full bg-primary-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
           href="#songbook-search"
         >
           <Search class="h-4 w-4" />
           {$t('app.search_placeholder')}
         </a>
-        <div class="flex flex-col gap-2 text-sm text-surface-600 dark:text-surface-300 sm:flex-row sm:items-center">
-          <p class="flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] dark:border-surface-700 dark:bg-surface-800/80">
+        <div class="flex flex-col gap-2 text-xs text-surface-600 dark:text-surface-300 sm:flex-row sm:items-center">
+          <p class="flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3 py-1.5 uppercase tracking-[0.18em] dark:border-surface-700 dark:bg-surface-800/80">
             <span class="text-surface-500 dark:text-surface-400">{$t('app.syncing')}</span>
             <span class="text-surface-900 dark:text-surface-100">{$syncStatus}</span>
           </p>
-          <p class="flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] dark:border-surface-700 dark:bg-surface-800/80">
+          <p class="flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3 py-1.5 uppercase tracking-[0.18em] dark:border-surface-700 dark:bg-surface-800/80">
             <span class="text-surface-500 dark:text-surface-400">{$t('app.last_synced')}</span>
             <span class="text-surface-900 dark:text-surface-100">{$lastSynced ? new Date($lastSynced).toLocaleString() : '—'}</span>
           </p>

--- a/src/lib/components/song/SongCard.svelte
+++ b/src/lib/components/song/SongCard.svelte
@@ -27,7 +27,11 @@
 
   const PREVIEW_LENGTH = 3;
 
-  $: printableItems = song.items.filter((item) => item.text.trim().length);
+  function itemText(item: Song['items'][number]) {
+    return typeof item.text === 'string' ? item.text : '';
+  }
+
+  $: printableItems = song.items.filter((item) => itemText(item).trim().length);
   $: previewItems = printableItems.slice(0, PREVIEW_LENGTH);
   $: remainingItems = printableItems.slice(PREVIEW_LENGTH);
   $: totalLines = printableItems.length;
@@ -89,14 +93,14 @@
 <div use:inView on:enterViewport={handleEnter}>
   {#if visible}
     <article
-      class="rounded-2xl border border-surface-200/70 bg-white p-5 shadow-sm transition hover:-translate-y-1 hover:shadow-lg dark:border-surface-700 dark:bg-surface-900/70"
+      class="rounded-xl border border-surface-200/70 bg-white p-4 shadow-sm transition hover:-translate-y-1 hover:shadow-lg dark:border-surface-700 dark:bg-surface-900/70 sm:rounded-2xl sm:p-5"
       use:listTransition={index}
     >
-      <div class="flex flex-col gap-6">
-        <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-          <div class="space-y-4">
+      <div class="flex flex-col gap-5">
+        <div class="flex flex-col gap-3.5 lg:flex-row lg:items-start lg:justify-between">
+          <div class="space-y-3">
             <div class="space-y-2">
-              <h3 class="text-xl font-semibold text-surface-900 dark:text-surface-50">{song.title}</h3>
+              <h3 class="text-lg font-semibold text-surface-900 dark:text-surface-50 sm:text-xl">{song.title}</h3>
               {#if lastUpdatedLabel}
                 <p class="text-xs text-surface-500 dark:text-surface-400">
                   {$t('app.updated_label')}: {lastUpdatedLabel}
@@ -117,7 +121,7 @@
           </div>
           <div class="flex flex-wrap justify-end gap-2 text-sm">
             <button
-              class={`inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-4 py-2 font-medium transition hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200 ${
+              class={`inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3.5 py-1.5 text-sm font-medium transition hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200 ${
                 isFavourite ? 'bg-primary-500/10 text-primary-600 dark:text-primary-300' : 'text-surface-700'
               }`}
               on:click={() => dispatch('toggleFavourite', `${song.id}-${song.language}`)}
@@ -127,7 +131,7 @@
               {isFavourite ? $t('app.remove_favourite') : $t('app.add_favourite')}
             </button>
             <button
-              class="inline-flex items-center gap-2 rounded-full bg-primary-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-600"
+              class="inline-flex items-center gap-2 rounded-full bg-primary-500 px-3.5 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-600"
               on:click={() => dispatch('open', song)}
               type="button"
             >
@@ -136,7 +140,7 @@
             </button>
             {#if remainingItems.length}
               <button
-                class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-4 py-2 text-sm font-medium text-surface-600 transition hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200"
+                class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3.5 py-1.5 text-sm font-medium text-surface-600 transition hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200"
                 on:click={() => (expanded = !expanded)}
                 type="button"
                 aria-expanded={expanded}
@@ -151,7 +155,7 @@
               </button>
             {/if}
             <button
-              class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-4 py-2 text-sm font-medium text-surface-600 transition hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200"
+              class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3.5 py-1.5 text-sm font-medium text-surface-600 transition hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200"
               on:click={copyShareLink}
               type="button"
             >
@@ -189,9 +193,9 @@
             >
               {#if viewMode === 'chords' && item.type === 'CHORD'}
                 <span class="block text-[11px] font-semibold text-primary-500">CHORDS</span>
-                <span class="mt-1 block text-base font-medium">{item.text}</span>
+                <span class="mt-1 block text-base font-medium">{itemText(item)}</span>
               {:else}
-                {item.text}
+                {itemText(item)}
               {/if}
             </p>
           {/each}
@@ -210,9 +214,9 @@
               >
                 {#if viewMode === 'chords' && item.type === 'CHORD'}
                   <span class="block text-[11px] font-semibold text-primary-500">CHORDS</span>
-                  <span class="mt-1 block text-base font-medium">{item.text}</span>
+                  <span class="mt-1 block text-base font-medium">{itemText(item)}</span>
                 {:else}
-                  {item.text}
+                  {itemText(item)}
                 {/if}
               </p>
             {/each}

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -6,8 +6,11 @@
     "language_label": "Language",
     "theme_label": "Theme",
     "theme": {
-        "light": "Light",
-        "dark": "Dark"
+      "light": "Light",
+      "dark": "Dark",
+      "sunset": "Sunset",
+      "forest": "Forest",
+      "ocean": "Ocean"
     },
     "light": "Light",
     "dark": "Dark",

--- a/src/lib/locales/pl.json
+++ b/src/lib/locales/pl.json
@@ -6,8 +6,11 @@
     "language_label": "Język",
     "theme_label": "Motyw",
     "theme": {
-        "light": "Jasny",
-        "dark": "Ciemny"
+      "light": "Jasny",
+      "dark": "Ciemny",
+      "sunset": "Zachód",
+      "forest": "Las",
+      "ocean": "Ocean"
     },
     "light": "Jasny",
     "dark": "Ciemny",

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -60,13 +60,13 @@
 </script>
 
 <div class="min-h-screen bg-gradient-to-b from-surface-50 via-surface-100 to-surface-50 text-surface-900 dark:from-surface-950 dark:via-surface-900 dark:to-surface-950">
-  <div class="mx-auto flex min-h-screen w-full max-w-6xl flex-col px-4 pb-16 sm:px-6 lg:px-8">
+  <div class="mx-auto flex min-h-screen w-full max-w-5xl flex-col px-3 pb-12 sm:px-5 lg:max-w-6xl lg:px-8">
     <AppHeader />
-    <main class="flex-1 py-8 sm:py-10 lg:py-12">
+    <main class="flex-1 py-6 sm:py-8 lg:py-10">
       <slot />
     </main>
-    <footer class="mt-12 border-t border-surface-200/60 py-6 text-sm text-surface-500 dark:border-surface-800 dark:text-surface-400">
-      <p class="font-semibold uppercase tracking-[0.2em] text-xs text-primary-500/80">Songbook</p>
+    <footer class="mt-10 border-t border-surface-200/60 py-5 text-xs text-surface-500 dark:border-surface-800 dark:text-surface-400 sm:text-sm">
+      <p class="font-semibold uppercase tracking-[0.18em] text-[11px] text-primary-500/80">Songbook</p>
       <p class="mt-2 max-w-xl leading-relaxed">Designed for musicians who need a simple, dependable song companion offline.</p>
     </footer>
   </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -105,21 +105,21 @@
 
 <section class="space-y-8 pb-16">
   <div
-    class="space-y-6 rounded-2xl border border-surface-200/70 bg-white/80 p-6 shadow-sm dark:border-surface-800/60 dark:bg-surface-900/70"
+    class="space-y-5 rounded-xl border border-surface-200/70 bg-white/80 p-5 shadow-sm dark:border-surface-800/60 dark:bg-surface-900/70 sm:rounded-2xl sm:p-6"
     use:fadeSlide
   >
     <div class="space-y-2">
       <label
-        class="text-xs font-semibold uppercase tracking-[0.28em] text-surface-500 dark:text-surface-400"
+        class="text-[11px] font-semibold uppercase tracking-[0.2em] text-surface-500 dark:text-surface-400"
         for="song-search"
       >
         {$t('app.search_placeholder')}
       </label>
-      <div class="flex items-center gap-3 rounded-xl border border-surface-200/70 bg-white px-4 py-3 shadow-inner dark:border-surface-800/60 dark:bg-surface-900/80">
+      <div class="flex items-center gap-2.5 rounded-xl border border-surface-200/70 bg-white px-3.5 py-2.5 shadow-inner dark:border-surface-800/60 dark:bg-surface-900/80">
         <Search class="h-4 w-4 text-primary-500" />
         <input
           id="song-search"
-          class="w-full bg-transparent text-base text-surface-800 outline-none placeholder:text-surface-400 dark:text-surface-100"
+          class="w-full bg-transparent text-sm text-surface-800 outline-none placeholder:text-surface-400 dark:text-surface-100 sm:text-base"
           type="search"
           placeholder={$t('app.search_placeholder')}
           bind:value={query}
@@ -127,7 +127,7 @@
         />
         {#if query}
           <button
-            class="text-xs font-semibold uppercase tracking-[0.28em] text-primary-500 transition hover:text-primary-400"
+            class="text-[11px] font-semibold uppercase tracking-[0.2em] text-primary-500 transition hover:text-primary-400"
             on:click={() => (query = '')}
             type="button"
           >
@@ -143,7 +143,7 @@
       <span>/</span>
       <span>{availableSongs.length}</span>
       {#if pageFilter}
-        <span class="rounded-full bg-primary-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-primary-500">
+        <span class="rounded-full bg-primary-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-primary-500">
           {$t('app.page_label')} {pageFilter}
         </span>
       {/if}
@@ -161,12 +161,12 @@
   </div>
 
   <div
-    class="space-y-6 rounded-2xl border border-surface-200/70 bg-white/80 p-6 shadow-sm dark:border-surface-800/60 dark:bg-surface-900/70"
+    class="space-y-5 rounded-xl border border-surface-200/70 bg-white/80 p-5 shadow-sm dark:border-surface-800/60 dark:bg-surface-900/70 sm:rounded-2xl sm:p-6"
     use:fadeSlide={{ axis: 'y', from: 30, delay: 0.05 }}
   >
     <div class="flex flex-wrap gap-2">
       <button
-        class={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition ${
+        class={`inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-sm font-semibold transition ${
           menuView === 'index'
             ? 'bg-primary-500 text-white shadow-sm'
             : 'border border-surface-200/70 bg-white text-surface-600 hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200'
@@ -178,7 +178,7 @@
         {$t('app.toggle_index')}
       </button>
       <button
-        class={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition ${
+        class={`inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-sm font-semibold transition ${
           menuView === 'favourites'
             ? 'bg-primary-500 text-white shadow-sm'
             : 'border border-surface-200/70 bg-white text-surface-600 hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200'
@@ -190,7 +190,7 @@
         {$t('app.toggle_favourites')}
       </button>
       <button
-        class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-surface-500 transition hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-300"
+        class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.2em] text-surface-500 transition hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-300"
         on:click={handleClearFilters}
         type="button"
       >
@@ -232,7 +232,7 @@
         </button>
       </div>
       <label class="flex items-center gap-3 text-sm font-medium text-surface-600 dark:text-surface-300">
-        <span class="text-xs font-semibold uppercase tracking-[0.3em] text-surface-500 dark:text-surface-400">
+        <span class="text-[11px] font-semibold uppercase tracking-[0.2em] text-surface-500 dark:text-surface-400">
           {$t('app.sort.label')}
         </span>
         <select

--- a/src/routes/song/[id]/+page.svelte
+++ b/src/routes/song/[id]/+page.svelte
@@ -34,6 +34,10 @@
       })
     : null;
 
+  function itemText(item: Song['items'][number]) {
+    return typeof item.text === 'string' ? item.text : '';
+  }
+
   function handleTabKeydown(event: KeyboardEvent, mode: 'basic' | 'chords') {
     if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight' && event.key !== 'ArrowUp' && event.key !== 'ArrowDown') {
       return;
@@ -62,25 +66,25 @@
   <div class="py-20 text-center text-sm text-[rgb(var(--text-secondary))]">{$t('app.syncing')}</div>
 {:else if song}
   <article
-    class="relative mx-auto max-w-4xl space-y-8 overflow-hidden rounded-[2.5rem] border border-primary-500/20 bg-white/85 p-8 shadow-2xl backdrop-blur-xl dark:border-surface-700/40 dark:bg-surface-900/80 sm:p-10 lg:p-14"
+    class="relative mx-auto max-w-4xl space-y-7 overflow-hidden rounded-2xl border border-primary-500/20 bg-white/90 p-5 shadow-2xl backdrop-blur-xl dark:border-surface-700/40 dark:bg-surface-900/80 sm:space-y-8 sm:rounded-[2.5rem] sm:p-8 lg:p-10"
   >
     <div class="pointer-events-none absolute inset-0 -z-10">
       <div class="absolute -top-24 left-10 h-48 w-48 rounded-full bg-primary-500/15 blur-[120px]"></div>
       <div class="absolute bottom-0 right-0 h-56 w-56 rounded-full bg-secondary-400/20 blur-[140px]"></div>
     </div>
 
-    <header class="relative space-y-6 text-center lg:text-left">
-      <div class="flex flex-1 flex-wrap items-center justify-between gap-4">
-        <div class="flex flex-wrap items-center gap-3">
+    <header class="relative space-y-5 text-center lg:text-left">
+      <div class="flex flex-1 flex-wrap items-center justify-between gap-3">
+        <div class="flex flex-wrap items-center gap-2.5">
           <button
-            class="inline-flex items-center gap-2 rounded-full border border-primary-500/20 bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-primary-500 transition hover:-translate-y-0.5 hover:border-primary-500 hover:text-primary-500 dark:border-surface-700/40 dark:bg-surface-900/70"
+            class="inline-flex items-center gap-2 rounded-full border border-primary-500/20 bg-white/80 px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.2em] text-primary-500 transition hover:-translate-y-0.5 hover:border-primary-500 hover:text-primary-500 dark:border-surface-700/40 dark:bg-surface-900/70"
             type="button"
             on:click={goBack}
           >
             {$t('app.back_action')}
           </button>
           <button
-            class="inline-flex items-center gap-2 rounded-full border border-primary-500/20 bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-primary-500 transition hover:-translate-y-0.5 hover:border-primary-500 hover:text-primary-500 dark:border-surface-700/40 dark:bg-surface-900/70"
+            class="inline-flex items-center gap-2 rounded-full border border-primary-500/20 bg-white/80 px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.2em] text-primary-500 transition hover:-translate-y-0.5 hover:border-primary-500 hover:text-primary-500 dark:border-surface-700/40 dark:bg-surface-900/70"
             type="button"
             on:click={() => goto('/')}
           >
@@ -88,7 +92,7 @@
           </button>
         </div>
         <button
-          class={`inline-flex items-center justify-center gap-2 rounded-full px-5 py-2 text-sm font-semibold transition ${
+          class={`inline-flex items-center justify-center gap-2 rounded-full px-4 py-1.5 text-sm font-semibold transition ${
             $favourites.includes(favouriteKey)
               ? 'bg-gradient-to-r from-primary-500 to-secondary-400 text-white shadow-lg'
               : 'border border-primary-500/25 bg-white/70 text-surface-600 hover:border-primary-500 hover:text-primary-500 dark:border-surface-700/40 dark:bg-surface-900/70 dark:text-surface-200'
@@ -101,23 +105,23 @@
         </button>
       </div>
 
-      <div class="space-y-4">
+      <div class="space-y-3">
         <div class="space-y-2">
-          <h1 class="text-balance text-3xl font-semibold text-surface-900 dark:text-surface-50 sm:text-4xl">{song.title}</h1>
+          <h1 class="text-balance text-2xl font-semibold text-surface-900 dark:text-surface-50 sm:text-3xl lg:text-4xl">{song.title}</h1>
           {#if lastUpdatedLabel}
-            <p class="text-xs uppercase tracking-[0.3em] text-primary-400/80">
+            <p class="text-[11px] uppercase tracking-[0.2em] text-primary-400/80">
               {$t('app.updated_label')}: {lastUpdatedLabel}
             </p>
           {/if}
         </div>
         <div class="flex flex-wrap justify-center gap-2 text-xs text-surface-500 dark:text-surface-300 lg:justify-start">
-          <span class="rounded-full bg-primary-500/10 px-3 py-1 font-semibold uppercase tracking-[0.2em] text-primary-500">
+          <span class="rounded-full bg-primary-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-primary-500">
             {$t('app.page_label')} {song.page}
           </span>
-          <span class="rounded-full bg-white/70 px-3 py-1 text-surface-600 dark:bg-surface-900/70 dark:text-surface-200">
+          <span class="rounded-full bg-white/80 px-3 py-1 text-[11px] text-surface-600 dark:bg-surface-900/70 dark:text-surface-200">
             {$t('app.source_label')} {song.source}
           </span>
-          <span class="rounded-full bg-white/70 px-3 py-1 text-surface-600 dark:bg-surface-900/70 dark:text-surface-200">
+          <span class="rounded-full bg-white/80 px-3 py-1 text-[11px] text-surface-600 dark:bg-surface-900/70 dark:text-surface-200">
             {$t('app.external_index')} {song.externalIndex}
           </span>
         </div>
@@ -129,7 +133,7 @@
         aria-label={$t('app.view_song')}
       >
         <button
-          class={`inline-flex items-center justify-center gap-2 rounded-full px-5 py-2 text-sm font-semibold transition ${
+          class={`inline-flex items-center justify-center gap-2 rounded-full px-4 py-1.5 text-sm font-semibold transition ${
             activeViewMode === 'basic'
               ? 'bg-gradient-to-r from-primary-500 to-secondary-400 text-white shadow-lg'
               : 'border border-primary-500/20 bg-white/70 text-surface-600 dark:border-surface-700/40 dark:bg-surface-800/70 dark:text-surface-200'
@@ -144,7 +148,7 @@
           {$t('app.view.basic')}
         </button>
         <button
-          class={`inline-flex items-center justify-center gap-2 rounded-full px-5 py-2 text-sm font-semibold transition ${
+          class={`inline-flex items-center justify-center gap-2 rounded-full px-4 py-1.5 text-sm font-semibold transition ${
             activeViewMode === 'chords'
               ? 'bg-gradient-to-r from-primary-500 to-secondary-400 text-white shadow-lg'
               : 'border border-primary-500/20 bg-white/70 text-surface-600 dark:border-surface-700/40 dark:bg-surface-800/70 dark:text-surface-200'
@@ -162,12 +166,12 @@
     </header>
 
     <section
-      class={`relative space-y-3 rounded-2xl border border-primary-500/10 bg-white/75 p-6 text-left text-base leading-relaxed shadow-inner dark:border-surface-700/40 dark:bg-surface-900/60 ${
-        activeViewMode === 'chords' ? 'lg:grid lg:grid-cols-[180px,1fr] lg:gap-6 lg:space-y-0' : ''
+      class={`relative space-y-3 rounded-xl border border-primary-500/10 bg-white/80 p-4 text-left text-sm leading-relaxed shadow-inner dark:border-surface-700/40 dark:bg-surface-900/60 sm:rounded-2xl sm:p-6 sm:text-base ${
+        activeViewMode === 'chords' ? 'lg:grid lg:grid-cols-[160px,1fr] lg:gap-6 lg:space-y-0' : ''
       }`}
     >
       {#each song.items as item}
-        {#if item.text.trim().length}
+        {#if itemText(item).trim().length}
           <p
             class={`whitespace-pre-line ${
               item.alignment === 'CENTER'
@@ -175,13 +179,13 @@
                 : item.alignment === 'RIGHT'
                 ? 'text-right'
                 : 'text-left'
-            } ${item.isBold ? 'font-semibold' : ''} ${item.isItalics ? 'italic' : ''}`}
+            } ${item.isBold ? 'font-semibold' : ''} ${item.isItalics ? 'italic' : ''} text-surface-700 dark:text-surface-200`}
           >
             {#if activeViewMode === 'chords' && item.type === 'CHORD'}
-              <span class="text-xs font-semibold uppercase tracking-[0.3em] text-primary-400/80">CHORDS</span>
-              <span class="mt-1 block text-base font-medium">{item.text}</span>
+              <span class="text-[11px] font-semibold uppercase tracking-[0.2em] text-primary-400/80">CHORDS</span>
+              <span class="mt-1 block text-sm font-medium sm:text-base">{itemText(item)}</span>
             {:else}
-              {item.text}
+              {itemText(item)}
             {/if}
           </p>
         {/if}


### PR DESCRIPTION
## Summary
- add additional theme presets with persisted selection and palette variables
- tighten spacing and typography for mobile across the header, search view, and song detail page while restoring lyric rendering
- update locale strings and dependency lockfile after reinstalling the missing adapter

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68da613538148327a8a2a412bd434241