### PR TITLE
Simplify songbook theming and language controls

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -36,143 +36,9 @@
     --color-surface-900: 55 48 163;
   }
 
-  :root[data-theme='dark'] {
-    color-scheme: dark;
-    --color-primary-50: 224 231 255;
-    --color-primary-100: 203 213 225;
-    --color-primary-200: 191 219 254;
-    --color-primary-300: 147 197 253;
-    --color-primary-400: 96 165 250;
-    --color-primary-500: 59 130 246;
-    --color-primary-600: 37 99 235;
-    --color-primary-700: 29 78 216;
-    --color-primary-800: 30 64 175;
-    --color-primary-900: 30 58 138;
-    --color-secondary-50: 240 253 250;
-    --color-secondary-100: 204 251 241;
-    --color-secondary-200: 153 246 228;
-    --color-secondary-300: 110 231 183;
-    --color-secondary-400: 52 211 153;
-    --color-secondary-500: 16 185 129;
-    --color-secondary-600: 5 150 105;
-    --color-secondary-700: 4 120 87;
-    --color-secondary-800: 6 95 70;
-    --color-secondary-900: 6 78 59;
-    --color-surface-50: 17 24 39;
-    --color-surface-100: 15 23 42;
-    --color-surface-200: 30 41 59;
-    --color-surface-300: 55 65 81;
-    --color-surface-400: 75 85 99;
-    --color-surface-500: 96 106 123;
-    --color-surface-600: 107 114 128;
-    --color-surface-700: 148 163 184;
-    --color-surface-800: 203 213 225;
-    --color-surface-900: 226 232 240;
-  }
-
-  :root[data-theme='sunset'] {
-    --color-primary-50: 255 247 237;
-    --color-primary-100: 255 237 213;
-    --color-primary-200: 254 215 170;
-    --color-primary-300: 253 186 116;
-    --color-primary-400: 251 146 60;
-    --color-primary-500: 249 115 22;
-    --color-primary-600: 234 88 12;
-    --color-primary-700: 194 65 12;
-    --color-primary-800: 154 52 18;
-    --color-primary-900: 124 45 18;
-    --color-secondary-50: 255 241 242;
-    --color-secondary-100: 255 228 230;
-    --color-secondary-200: 254 205 211;
-    --color-secondary-300: 253 164 175;
-    --color-secondary-400: 251 113 133;
-    --color-secondary-500: 244 63 94;
-    --color-secondary-600: 225 29 72;
-    --color-secondary-700: 190 24 60;
-    --color-secondary-800: 159 18 57;
-    --color-secondary-900: 136 19 55;
-    --color-surface-50: 255 248 244;
-    --color-surface-100: 254 236 226;
-    --color-surface-200: 253 222 206;
-    --color-surface-300: 252 211 185;
-    --color-surface-400: 249 196 160;
-    --color-surface-500: 243 169 125;
-    --color-surface-600: 224 140 93;
-    --color-surface-700: 191 110 69;
-    --color-surface-800: 159 88 57;
-    --color-surface-900: 133 73 50;
-  }
-
-  :root[data-theme='forest'] {
-    color-scheme: dark;
-    --color-primary-50: 236 253 245;
-    --color-primary-100: 209 250 229;
-    --color-primary-200: 167 243 208;
-    --color-primary-300: 110 231 183;
-    --color-primary-400: 52 211 153;
-    --color-primary-500: 34 197 94;
-    --color-primary-600: 22 163 74;
-    --color-primary-700: 21 128 61;
-    --color-primary-800: 22 101 52;
-    --color-primary-900: 20 83 45;
-    --color-secondary-50: 236 254 255;
-    --color-secondary-100: 207 250 254;
-    --color-secondary-200: 165 243 252;
-    --color-secondary-300: 103 232 249;
-    --color-secondary-400: 34 211 238;
-    --color-secondary-500: 14 165 233;
-    --color-secondary-600: 8 145 178;
-    --color-secondary-700: 14 116 144;
-    --color-secondary-800: 21 94 117;
-    --color-secondary-900: 22 78 99;
-    --color-surface-50: 13 17 23;
-    --color-surface-100: 15 23 30;
-    --color-surface-200: 17 35 38;
-    --color-surface-300: 22 53 46;
-    --color-surface-400: 34 78 60;
-    --color-surface-500: 45 102 74;
-    --color-surface-600: 74 131 102;
-    --color-surface-700: 125 168 144;
-    --color-surface-800: 180 208 186;
-    --color-surface-900: 209 231 212;
-  }
-
-  :root[data-theme='ocean'] {
-    --color-primary-50: 236 254 255;
-    --color-primary-100: 207 250 254;
-    --color-primary-200: 165 243 252;
-    --color-primary-300: 103 232 249;
-    --color-primary-400: 34 211 238;
-    --color-primary-500: 14 165 233;
-    --color-primary-600: 8 145 178;
-    --color-primary-700: 14 116 144;
-    --color-primary-800: 21 94 117;
-    --color-primary-900: 22 78 99;
-    --color-secondary-50: 239 246 255;
-    --color-secondary-100: 219 234 254;
-    --color-secondary-200: 191 219 254;
-    --color-secondary-300: 147 197 253;
-    --color-secondary-400: 96 165 250;
-    --color-secondary-500: 59 130 246;
-    --color-secondary-600: 37 99 235;
-    --color-secondary-700: 29 78 216;
-    --color-secondary-800: 30 64 175;
-    --color-secondary-900: 30 58 138;
-    --color-surface-50: 240 249 255;
-    --color-surface-100: 224 242 254;
-    --color-surface-200: 186 230 253;
-    --color-surface-300: 145 215 250;
-    --color-surface-400: 103 197 241;
-    --color-surface-500: 59 172 227;
-    --color-surface-600: 34 139 199;
-    --color-surface-700: 30 112 168;
-    --color-surface-800: 31 89 141;
-    --color-surface-900: 30 73 117;
-  }
-
   body {
     font-family: Inter, 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    @apply min-h-screen bg-transparent text-surface-900 antialiased dark:text-surface-50;
+    @apply min-h-screen bg-transparent text-surface-900 antialiased;
   }
 
   body.is-lenis {
@@ -223,7 +89,7 @@
 
 @layer utilities {
   .backdrop-glass {
-    @apply bg-white/60 backdrop-blur-xl dark:bg-surface-800/80;
+    @apply bg-white/60 backdrop-blur-xl;
   }
 
   .gradient-border {

--- a/src/lib/components/layout/AppHeader.svelte
+++ b/src/lib/components/layout/AppHeader.svelte
@@ -1,77 +1,27 @@
 <script lang="ts">
   import { browser } from '$app/environment';
   import { t } from 'svelte-i18n';
-  import { language, theme, themeOptions } from '$lib/stores/preferences';
+  import { language } from '$lib/stores/preferences';
   import { isSyncing, lastSynced } from '$lib/stores/songStore';
   import { derived } from 'svelte/store';
-  import { Languages, Moon, Search, Sun } from 'lucide-svelte';
-  import type { ThemeName } from '$lib/stores/preferences';
-  import Select from 'svelte-select';
+  import { Languages, Search } from 'lucide-svelte';
+  import type { SongLanguage } from '$lib/types/song';
 
-  type ThemeSelectItem = {
-    value: ThemeName;
+  type LanguageOption = {
+    code: SongLanguage;
     label: string;
-    swatch: [string, string];
+    shortLabel: string;
   };
 
   const syncStatus = derived(isSyncing, ($isSyncing) => ($isSyncing ? $t('app.syncing') : $t('app.brand_available_offline')));
 
-  function selectTheme(name: ThemeName) {
-    theme.set(name);
-  }
+  const languageOptions: LanguageOption[] = [
+    { code: 'PL', label: 'Polski', shortLabel: 'PL' },
+    { code: 'EN', label: 'English', shortLabel: 'EN' }
+  ];
 
-  function themeMode(name: ThemeName) {
-    return themeOptions.find((option) => option.id === name)?.mode ?? 'light';
-  }
-
-  const fallbackSwatch: [string, string] = themeOptions[0]?.swatch ?? ['#6366f1', '#0ea5e9'];
-  const themeSelectStyle = `
-    --border: 0;
-    --border-hover: 0;
-    --border-focused: 0;
-    --border-radius: 9999px;
-    --padding: 0;
-    --font-size: 12px;
-    --height: 34px;
-    --value-container-padding: 0;
-    --selected-item-padding: 0;
-    --placeholder-color: rgb(var(--color-surface-500));
-    --placeholder-opacity: 1;
-    --item-color: rgb(var(--color-surface-700));
-    --item-hover-bg: rgb(var(--color-primary-500) / 0.12);
-    --item-hover-color: rgb(var(--color-primary-600));
-    --item-is-active-bg: rgb(var(--color-primary-500) / 0.18);
-    --item-is-active-color: rgb(var(--color-primary-600));
-    --list-background: rgb(var(--color-surface-50));
-    --list-border: 1px solid rgb(var(--color-surface-200) / 0.8);
-    --list-border-radius: 12px;
-    --list-shadow: 0 16px 32px rgb(15 23 42 / 0.12);
-    --input-color: rgb(var(--color-surface-700));
-    --selected-item-color: rgb(var(--color-surface-700));
-    --chevron-color: rgb(var(--color-surface-400));
-    --chevron-width: 16px;
-    --chevron-height: 16px;
-  `;
-
-  let themeSelectItems: ThemeSelectItem[] = [];
-  let selectedThemeOption: ThemeSelectItem | undefined;
-  let themeLabel = '';
-
-  $: themeSelectItems = themeOptions.map((option) => ({
-    value: option.id,
-    label: $t(option.labelKey),
-    swatch: option.swatch
-  }));
-
-  $: selectedThemeOption = themeSelectItems.find((item) => item.value === $theme) ?? themeSelectItems[0];
-
-  $: themeLabel = $t('app.theme_label');
-
-  function handleThemeSelect(event: CustomEvent<ThemeSelectItem>) {
-    const selection = event.detail;
-    if (selection?.value) {
-      selectTheme(selection.value);
-    }
+  function setLanguage(code: SongLanguage) {
+    language.set(code);
   }
 
   function focusSearch() {
@@ -87,79 +37,44 @@
 </script>
 
 <section class="pt-6 sm:pt-10 lg:pt-12">
-  <div class="rounded-xl border border-surface-200/70 bg-white/80 p-5 shadow-sm backdrop-blur dark:border-surface-800/60 dark:bg-surface-900/70 sm:rounded-2xl sm:p-7">
+  <div class="rounded-xl border border-surface-200/70 bg-white/80 p-5 shadow-sm backdrop-blur sm:rounded-2xl sm:p-7">
     <div class="flex flex-col gap-5">
       <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div class="space-y-2">
           <p class="text-[11px] font-semibold uppercase tracking-[0.22em] text-primary-500">
             {$t('app.brand_global')}
           </p>
-          <h1 class="text-balance text-2xl font-semibold text-surface-900 dark:text-surface-50 sm:text-3xl lg:text-4xl">
+          <h1 class="text-balance text-2xl font-semibold text-surface-900 sm:text-3xl lg:text-4xl">
             {$t('app.title')}
           </h1>
-          <!-- <p class="max-w-2xl text-sm leading-relaxed text-surface-600 dark:text-surface-300">
+          <!-- <p class="max-w-2xl text-sm leading-relaxed text-surface-600">
             {$t('app.tagline')}
           </p> -->
         </div>
-        <div class="flex flex-wrap items-center gap-2 sm:justify-end">
-          <div class="flex flex-wrap items-center gap-2 rounded-full border border-surface-200/80 bg-white px-3 py-1.5 text-xs font-semibold text-surface-600 shadow-sm dark:border-surface-700 dark:bg-surface-800/90 dark:text-surface-200">
-            {#if themeMode($theme) === 'dark'}
-              <Moon class="h-4 w-4" aria-hidden="true" />
-            {:else}
-              <Sun class="h-4 w-4" aria-hidden="true" />
-            {/if}
-            <span class="hidden uppercase tracking-[0.18em] text-surface-500 dark:text-surface-400 sm:inline">
-              {$t('app.theme_label')}
-            </span>
-            <Select
-              class="theme-select min-w-[160px] flex-1"
-              items={themeSelectItems}
-              value={selectedThemeOption}
-              itemId="value"
-              placeholder={themeLabel}
-              searchable={false}
-              clearable={false}
-              showChevron={true}
-              listOffset={8}
-              containerStyles={themeSelectStyle}
-              inputAttributes={{ 'aria-label': themeLabel }}
-              on:select={handleThemeSelect}
-            >
-              <svelte:fragment slot="selection" let:selection>
-                <div class="flex w-full items-center gap-2 text-left text-[11px] font-semibold uppercase tracking-[0.16em] text-surface-600 dark:text-surface-300">
-                  <span
-                    aria-hidden="true"
-                    class="h-2.5 w-6 rounded-full"
-                    style={`background: linear-gradient(90deg, ${(selection?.swatch ?? fallbackSwatch)[0]}, ${(selection?.swatch ?? fallbackSwatch)[1]});`}
-                  ></span>
-                  <span class="truncate text-surface-700 dark:text-surface-200">
-                    {selection ? selection.label : themeLabel}
-                  </span>
-                </div>
-              </svelte:fragment>
-              <svelte:fragment slot="item" let:item>
-                <div class="flex items-center gap-3">
-                  <span
-                    aria-hidden="true"
-                    class="h-2.5 w-6 rounded-full"
-                    style={`background: linear-gradient(90deg, ${item.swatch[0]}, ${item.swatch[1]});`}
-                  ></span>
-                  <span class="text-sm font-medium text-surface-700 dark:text-surface-100">{item.label}</span>
-                </div>
-              </svelte:fragment>
-            </Select>
-          </div>
-          <label class="inline-flex items-center gap-2 rounded-full border border-surface-200/80 bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-surface-600 shadow-sm transition hover:border-primary-400 focus-within:ring-2 focus-within:ring-primary-400 focus-within:ring-offset-2 focus-within:ring-offset-white dark:border-surface-700 dark:bg-surface-800/90 dark:text-surface-200 dark:focus-within:ring-offset-surface-900">
+        <div class="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end sm:gap-4">
+          <div class="flex items-center gap-3 rounded-full border border-surface-200/80 bg-white px-3 py-1.5 text-xs font-semibold text-surface-600 shadow-sm">
             <Languages class="h-4 w-4 text-primary-500" />
-            <span class="hidden text-[11px] sm:inline">{$t('app.language_label')}</span>
-            <select
-              class="rounded-full border-none bg-transparent text-sm font-semibold text-surface-700 outline-none dark:text-surface-200"
-              bind:value={$language}
-            >
-              <option value="PL">Polski</option>
-              <option value="EN">English</option>
-            </select>
-          </label>
+            <span class="hidden text-[11px] uppercase tracking-[0.18em] text-surface-500 sm:inline">
+              {$t('app.language_label')}
+            </span>
+            <div class="grid grid-cols-2 gap-1 rounded-full bg-surface-100 p-1">
+              {#each languageOptions as option}
+                <button
+                  class={`rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] transition ${
+                    $language === option.code
+                      ? 'bg-white text-primary-600 shadow'
+                      : 'text-surface-500 hover:text-primary-500'
+                  }`}
+                  type="button"
+                  aria-pressed={$language === option.code}
+                  on:click={() => setLanguage(option.code)}
+                >
+                  <span class="hidden sm:inline">{option.label}</span>
+                  <span class="sm:hidden">{option.shortLabel}</span>
+                </button>
+              {/each}
+            </div>
+          </div>
         </div>
       </div>
       <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -171,14 +86,13 @@
           <Search class="h-4 w-4" />
           {$t('app.search_placeholder')}
         </button>
-        <div class="flex flex-col gap-2 text-xs text-surface-600 dark:text-surface-300 sm:flex-row sm:items-center">
-          <p class="flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3 py-1.5 uppercase tracking-[0.18em] dark:border-surface-700 dark:bg-surface-800/80">
-            <!-- <span class="text-surface-500 dark:text-surface-400">{$t('app.syncing')}</span> -->
-            <span class="text-surface-900 dark:text-surface-100">{$syncStatus}</span>
+        <div class="flex flex-col gap-2 text-xs text-surface-600 sm:flex-row sm:items-center">
+          <p class="flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3 py-1.5 uppercase tracking-[0.18em]">
+            <span class="text-surface-900">{$syncStatus}</span>
           </p>
-          <p class="flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3 py-1.5 uppercase tracking-[0.18em] dark:border-surface-700 dark:bg-surface-800/80">
-            <span class="text-surface-500 dark:text-surface-400">{$t('app.last_synced')}</span>
-            <span class="text-surface-900 dark:text-surface-100">{$lastSynced ? new Date($lastSynced).toLocaleString() : '—'}</span>
+          <p class="flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3 py-1.5 uppercase tracking-[0.18em]">
+            <span class="text-surface-500">{$t('app.last_synced')}</span>
+            <span class="text-surface-900">{$lastSynced ? new Date($lastSynced).toLocaleString() : '—'}</span>
           </p>
         </div>
       </div>

--- a/src/lib/components/song/SongCard.svelte
+++ b/src/lib/components/song/SongCard.svelte
@@ -93,36 +93,36 @@
 <div use:inView on:enterViewport={handleEnter}>
   {#if visible}
     <article
-      class="rounded-xl border border-surface-200/70 bg-white p-4 shadow-sm transition hover:-translate-y-1 hover:shadow-lg dark:border-surface-700 dark:bg-surface-900/70 sm:rounded-2xl sm:p-5"
+      class="rounded-xl border border-surface-200/70 bg-white p-4 shadow-sm transition hover:-translate-y-1 hover:shadow-lg sm:rounded-2xl sm:p-5"
       use:listTransition={index}
     >
       <div class="flex flex-col gap-5">
         <div class="flex flex-col gap-3.5 lg:flex-row lg:items-start lg:justify-between">
           <div class="space-y-3">
             <div class="space-y-2">
-              <h3 class="text-lg font-semibold text-surface-900 dark:text-surface-50 sm:text-xl">{song.title}</h3>
+              <h3 class="text-lg font-semibold text-surface-900 sm:text-xl">{song.title}</h3>
               {#if lastUpdatedLabel}
-                <p class="text-xs text-surface-500 dark:text-surface-400">
+                <p class="text-xs text-surface-500">
                   {$t('app.updated_label')}: {lastUpdatedLabel}
                 </p>
               {/if}
             </div>
-            <div class="flex flex-wrap items-center gap-2 text-xs text-surface-500 dark:text-surface-300">
-              <span class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3 py-1 font-medium text-surface-700 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-100">
+            <div class="flex flex-wrap items-center gap-2 text-xs text-surface-500">
+              <span class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3 py-1 font-medium text-surface-700">
                 {$t('app.page_label')} {song.page}
               </span>
-              <span class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3 py-1 text-surface-600 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200">
+              <span class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3 py-1 text-surface-600">
                 {$t('app.source_label')} {song.source}
               </span>
-              <span class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3 py-1 text-surface-600 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200">
+              <span class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3 py-1 text-surface-600">
                 {$t('app.external_index')} {song.externalIndex}
               </span>
             </div>
           </div>
           <div class="flex flex-wrap justify-end gap-2 text-sm">
             <button
-              class={`inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3.5 py-1.5 text-sm font-medium transition hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200 ${
-                isFavourite ? 'bg-primary-500/10 text-primary-600 dark:text-primary-300' : 'text-surface-700'
+              class={`inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3.5 py-1.5 text-sm font-medium transition hover:border-primary-400 hover:text-primary-500 ${
+                isFavourite ? 'bg-primary-500/10 text-primary-600' : 'text-surface-700'
               }`}
               on:click={() => dispatch('toggleFavourite', `${song.id}-${song.language}`)}
               type="button"
@@ -140,7 +140,7 @@
             </button>
             {#if remainingItems.length}
               <button
-                class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3.5 py-1.5 text-sm font-medium text-surface-600 transition hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200"
+                class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3.5 py-1.5 text-sm font-medium text-surface-600 transition hover:border-primary-400 hover:text-primary-500"
                 on:click={() => (expanded = !expanded)}
                 type="button"
                 aria-expanded={expanded}
@@ -155,7 +155,7 @@
               </button>
             {/if}
             <button
-              class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3.5 py-1.5 text-sm font-medium text-surface-600 transition hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200"
+              class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3.5 py-1.5 text-sm font-medium text-surface-600 transition hover:border-primary-400 hover:text-primary-500"
               on:click={copyShareLink}
               type="button"
             >
@@ -165,28 +165,28 @@
           </div>
         </div>
 
-        <!-- <div class="rounded-xl border border-surface-200/70 bg-white px-4 py-4 text-xs dark:border-surface-700 dark:bg-surface-900/70">
+        <!-- <div class="rounded-xl border border-surface-200/70 bg-white px-4 py-4 text-xs">
           <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p class="text-xs font-semibold uppercase tracking-[0.2em] text-primary-500/90">{$t('app.density_label')}</p>
               <div class="mt-2 flex items-center gap-3">
-                <span class="relative inline-flex h-2 w-36 overflow-hidden rounded-full bg-surface-200/70 dark:bg-surface-800">
+                <span class="relative inline-flex h-2 w-36 overflow-hidden rounded-full bg-surface-200/70">
                   <span
                     class="absolute inset-y-0 left-0 origin-left rounded-full bg-primary-500"
                     style:transform={`scaleX(${Math.max(density, 0.05)})`}
                     style:transition={prefersReducedMotion ? 'none' : 'transform 420ms cubic-bezier(0.22, 1, 0.36, 1)'}
                   />
                 </span>
-                <span class="text-sm font-semibold text-surface-700 dark:text-surface-100">{densityPercentage}%</span>
+                <span class="text-sm font-semibold text-surface-700">{densityPercentage}%</span>
               </div>
             </div>
-            <p class="text-xs text-surface-500 dark:text-surface-300">
+            <p class="text-xs text-surface-500">
               {$t('app.density_caption', { values: { chords: chordLines, total: totalLines } })}
             </p>
           </div>
         </div> -->
 
-        <div class="space-y-3 text-sm leading-relaxed text-surface-700 dark:text-surface-200">
+        <div class="space-y-3 text-sm leading-relaxed text-surface-700">
           {#each previewItems as item}
             <p
               class={`whitespace-pre-line ${alignmentClass(item.alignment)} ${item.isBold ? 'font-semibold' : ''} ${item.isItalics ? 'italic' : ''}`}
@@ -200,14 +200,14 @@
             </p>
           {/each}
           {#if remainingItems.length && !expanded}
-            <p class="text-xs italic text-surface-500 dark:text-surface-300">
+            <p class="text-xs italic text-surface-500">
               {$t('app.preview_remaining', { values: { count: remainingItems.length } })}
             </p>
           {/if}
         </div>
 
         {#if remainingItems.length && expanded}
-          <div class="space-y-3 text-sm leading-relaxed text-surface-700 dark:text-surface-200" transition:fade>
+          <div class="space-y-3 text-sm leading-relaxed text-surface-700" transition:fade>
             {#each remainingItems as item}
               <p
                 class={`whitespace-pre-line ${alignmentClass(item.alignment)} ${item.isBold ? 'font-semibold' : ''} ${item.isItalics ? 'italic' : ''}`}

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -4,17 +4,6 @@
     "tagline": "Church worship songs at your fingertips",
     "search_placeholder": "Search by title, lyric, page or index…",
     "language_label": "Language",
-    "theme_label": "Theme",
-    "theme": {
-      "light": "Light",
-      "dark": "Dark",
-      "sunset": "Sunset",
-      "forest": "Forest",
-      "ocean": "Ocean"
-    },
-    "light": "Light",
-    "dark": "Dark",
-    "system": "System",
     "view": {
       "basic": "Lyrics",
       "chords": "Chords view"

--- a/src/lib/locales/pl.json
+++ b/src/lib/locales/pl.json
@@ -4,17 +4,6 @@
     "tagline": "Zborowy śpiewnik zawsze pod ręką",
     "search_placeholder": "Szukaj po tytule, tekście, stronie lub indeksie…",
     "language_label": "Język",
-    "theme_label": "Motyw",
-    "theme": {
-      "light": "Jasny",
-      "dark": "Ciemny",
-      "sunset": "Zachód",
-      "forest": "Las",
-      "ocean": "Ocean"
-    },
-    "light": "Jasny",
-    "dark": "Ciemny",
-    "system": "Systemowy",
     "view": {
       "basic": "Tekst",
       "chords": "Akordy"

--- a/src/lib/stores/preferences.ts
+++ b/src/lib/stores/preferences.ts
@@ -11,46 +11,6 @@ const THEME_KEY = 'songbook-theme';
 const defaultLanguage: SongLanguage = 'PL';
 const defaultViewMode: SongViewMode = 'basic';
 
-export type ThemeName = 'light' | 'dark' | 'sunset' | 'forest' | 'ocean';
-
-type ThemeDefinition = {
-  mode: 'light' | 'dark';
-  labelKey: `app.theme.${string}`;
-  swatch: [string, string];
-};
-
-const themeDefinitions: Record<ThemeName, ThemeDefinition> = {
-  light: {
-    mode: 'light',
-    labelKey: 'app.theme.light',
-    swatch: ['#6366f1', '#0ea5e9']
-  },
-  dark: {
-    mode: 'dark',
-    labelKey: 'app.theme.dark',
-    swatch: ['#4338ca', '#0ea5e9']
-  },
-  sunset: {
-    mode: 'light',
-    labelKey: 'app.theme.sunset',
-    swatch: ['#f97316', '#ec4899']
-  },
-  forest: {
-    mode: 'dark',
-    labelKey: 'app.theme.forest',
-    swatch: ['#22c55e', '#0f766e']
-  },
-  ocean: {
-    mode: 'light',
-    labelKey: 'app.theme.ocean',
-    swatch: ['#0ea5e9', '#6366f1']
-  }
-};
-
-const orderedThemes: ThemeName[] = ['light', 'dark', 'sunset', 'forest', 'ocean'];
-
-export const themeOptions = orderedThemes.map((id) => ({ id, ...themeDefinitions[id] }));
-
 function createPersistedStore<T>(key: string, initial: T) {
   const store = writable<T>(initial, (set) => {
     if (!browser) return;
@@ -78,47 +38,11 @@ export const language = createPersistedStore<SongLanguage>(LANGUAGE_KEY, default
 export const viewMode = createPersistedStore<SongViewMode>(VIEW_KEY, defaultViewMode);
 export const favourites = createPersistedStore<string[]>(FAV_KEY, []);
 
-function isValidTheme(value: string): value is ThemeName {
-  return Object.prototype.hasOwnProperty.call(themeDefinitions, value);
-}
-
-function getInitialTheme(): ThemeName {
-  if (!browser) return 'light';
-  const stored = window.localStorage.getItem(THEME_KEY);
-  if (stored) {
-    try {
-      const parsed = JSON.parse(stored);
-      if (typeof parsed === 'string' && isValidTheme(parsed)) return parsed;
-    } catch (error) {
-      console.warn('Failed to parse stored theme', error);
-    }
-  }
-  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-}
-
-function applyTheme(themeName: ThemeName) {
-  if (!browser) return;
-  const definition = themeDefinitions[themeName];
-  document.documentElement.dataset.theme = themeName;
-  document.documentElement.classList.toggle('dark', definition.mode === 'dark');
-}
-
-const initialTheme = getInitialTheme();
-export const theme = writable<ThemeName>(initialTheme);
-
 if (browser) {
-  applyTheme(initialTheme);
-  theme.subscribe((value) => {
-    window.localStorage.setItem(THEME_KEY, JSON.stringify(value));
-    applyTheme(value);
-  });
-}
+  window.localStorage.removeItem(THEME_KEY);
+  document.documentElement.dataset.theme = 'light';
+  document.documentElement.classList.remove('dark');
 
-export function toggleTheme() {
-  theme.update((current) => (current === 'dark' ? 'light' : 'dark'));
-}
-
-if (browser) {
   language.subscribe(($language) => {
     locale.set($language.toLowerCase());
     document.documentElement.lang = $language.toLowerCase();

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -59,13 +59,13 @@
   });
 </script>
 
-<div class="min-h-screen bg-gradient-to-b from-surface-50 via-surface-100 to-surface-50 text-surface-900 dark:from-surface-950 dark:via-surface-900 dark:to-surface-950">
+<div class="min-h-screen bg-gradient-to-b from-surface-50 via-surface-100 to-surface-50 text-surface-900">
   <div class="mx-auto flex min-h-screen w-full max-w-5xl flex-col px-3 pb-12 sm:px-5 lg:max-w-6xl lg:px-8">
     <AppHeader />
     <main class="flex-1 py-6 sm:py-8 lg:py-10">
       <slot />
     </main>
-    <footer class="mt-10 border-t border-surface-200/60 py-5 text-xs text-surface-500 dark:border-surface-800 dark:text-surface-400 sm:text-sm">
+    <footer class="mt-10 border-t border-surface-200/60 py-5 text-xs text-surface-500 sm:text-sm">
       <p class="font-semibold uppercase tracking-[0.18em] text-[11px] text-primary-500/80">Wspólnota Biblijna KWCh</p>
       <p class="mt-2 max-w-xl leading-relaxed">
         <a

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -94,21 +94,21 @@
 
 <section class="space-y-8 pb-16">
   <div
-    class="space-y-5 rounded-xl border border-surface-200/70 bg-white/80 p-5 shadow-sm dark:border-surface-800/60 dark:bg-surface-900/70 sm:rounded-2xl sm:p-6"
+    class="space-y-5 rounded-xl border border-surface-200/70 bg-white/80 p-5 shadow-sm sm:rounded-2xl sm:p-6"
     use:fadeSlide
   >
     <div class="space-y-2">
       <!-- <label
-        class="text-[11px] font-semibold uppercase tracking-[0.2em] text-surface-500 dark:text-surface-400"
+        class="text-[11px] font-semibold uppercase tracking-[0.2em] text-surface-500"
         for="song-search"
       >
         {$t('app.search_placeholder')}
       </label> -->
-      <div class="flex items-center gap-2.5 rounded-xl border border-surface-200/70 bg-white px-3.5 py-2.5 shadow-inner dark:border-surface-800/60 dark:bg-surface-900/80">
+      <div class="flex items-center gap-2.5 rounded-xl border border-surface-200/70 bg-white px-3.5 py-2.5 shadow-inner">
         <Search class="h-4 w-4 text-primary-500" />
         <input
           id="song-search"
-          class="w-full bg-transparent text-sm text-surface-800 outline-none placeholder:text-surface-400 dark:text-surface-100 sm:text-base"
+          class="w-full bg-transparent text-sm text-surface-800 outline-none placeholder:text-surface-400 sm:text-base"
           type="search"
           placeholder={$t('app.search_placeholder')}
           bind:value={query}
@@ -124,11 +124,11 @@
           </button>
         {/if}
       </div>
-      <!-- <p class="text-xs text-surface-500 dark:text-surface-400">{$t('app.search_hint')}</p> -->
+      <!-- <p class="text-xs text-surface-500">{$t('app.search_hint')}</p> -->
     </div>
 
-    <div class="flex flex-wrap items-center gap-3 text-sm text-surface-600 dark:text-surface-300">
-      <span class="font-semibold text-surface-900 dark:text-surface-50">{filteredSongs.length}</span>
+    <div class="flex flex-wrap items-center gap-3 text-sm text-surface-600">
+      <span class="font-semibold text-surface-900">{filteredSongs.length}</span>
       <span>/</span>
       <span>{availableSongs.length}</span>
       {#if pageFilter}
@@ -141,7 +141,7 @@
     {#if filterBadges.length}
       <div class="flex flex-wrap gap-2">
         {#each filterBadges as badge}
-          <span class="inline-flex items-center gap-2 rounded-full border border-primary-200/60 bg-primary-50 px-3 py-1 text-xs font-semibold text-primary-600 dark:border-primary-500/40 dark:bg-primary-500/10 dark:text-primary-300">
+          <span class="inline-flex items-center gap-2 rounded-full border border-primary-200/60 bg-primary-50 px-3 py-1 text-xs font-semibold text-primary-600">
             {badge}
           </span>
         {/each}
@@ -150,50 +150,50 @@
   </div>
 
   <div
-    class="space-y-5 rounded-xl border border-surface-200/70 bg-white/80 p-5 shadow-sm dark:border-surface-800/60 dark:bg-surface-900/70 sm:rounded-2xl sm:p-6"
+    class="space-y-5 rounded-xl border border-surface-200/70 bg-white/80 p-5 shadow-sm sm:rounded-2xl sm:p-6"
     use:fadeSlide={{ axis: 'y', from: 30, delay: 0.05 }}
   >
-    <div class="flex flex-wrap gap-2">
-      <button
-        class={`inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-sm font-semibold transition ${
-          menuView === 'index'
-            ? 'bg-primary-500 text-white shadow-sm'
-            : 'border border-surface-200/70 bg-white text-surface-600 hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200'
-        }`}
-        on:click={() => (menuView = 'index')}
-        type="button"
-      >
-        <LayoutList class="h-4 w-4" />
-        {$t('app.toggle_index')}
-      </button>
-      <button
-        class={`inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-sm font-semibold transition ${
-          menuView === 'favourites'
-            ? 'bg-primary-500 text-white shadow-sm'
-            : 'border border-surface-200/70 bg-white text-surface-600 hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200'
-        }`}
-        on:click={() => (menuView = 'favourites')}
-        type="button"
-      >
-        <Heart class="h-4 w-4" />
-        {$t('app.toggle_favourites')}
-      </button>
-      <button
-        class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.2em] text-surface-500 transition hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-300"
-        on:click={handleClearFilters}
-        type="button"
-      >
-        {$t('app.reset_filters')}
-      </button>
-    </div>
+    <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+      <div class="flex flex-wrap gap-2">
+        <button
+          class={`inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-sm font-semibold transition ${
+            menuView === 'index'
+              ? 'bg-primary-500 text-white shadow-sm'
+              : 'border border-surface-200/70 bg-white text-surface-600 hover:border-primary-400 hover:text-primary-500'
+          }`}
+          on:click={() => (menuView = 'index')}
+          type="button"
+        >
+          <LayoutList class="h-4 w-4" />
+          {$t('app.toggle_index')}
+        </button>
+        <button
+          class={`inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-sm font-semibold transition ${
+            menuView === 'favourites'
+              ? 'bg-primary-500 text-white shadow-sm'
+              : 'border border-surface-200/70 bg-white text-surface-600 hover:border-primary-400 hover:text-primary-500'
+          }`}
+          on:click={() => (menuView = 'favourites')}
+          type="button"
+        >
+          <Heart class="h-4 w-4" />
+          {$t('app.toggle_favourites')}
+        </button>
+        <button
+          class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 bg-white px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.2em] text-surface-500 transition hover:border-primary-400 hover:text-primary-500"
+          on:click={handleClearFilters}
+          type="button"
+        >
+          {$t('app.reset_filters')}
+        </button>
+      </div>
 
-    <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-end">
-      <label class="flex items-center gap-3 text-sm font-medium text-surface-600 dark:text-surface-300 lg:ml-auto">
-        <span class="text-[11px] font-semibold uppercase tracking-[0.2em] text-surface-500 dark:text-surface-400">
+      <label class="flex items-center gap-3 text-sm font-medium text-surface-600 lg:ml-auto">
+        <span class="text-[11px] font-semibold uppercase tracking-[0.2em] text-surface-500">
           {$t('app.sort.label')}
         </span>
         <select
-          class="rounded-full border border-surface-200/70 bg-white px-3 py-2 text-sm font-semibold text-surface-700 outline-none dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-100"
+          class="rounded-full border border-surface-200/70 bg-white px-3 py-2 text-sm font-semibold text-surface-700 outline-none"
           bind:value={sortMode}
         >
           {#each sortOptions as option}
@@ -206,7 +206,7 @@
     <div class="space-y-4">
       <!-- <input
         id="page-search"
-        class="w-full rounded-xl border border-surface-200/70 bg-white px-3 py-2 text-sm text-surface-700 outline-none placeholder:text-surface-400 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-100"
+        class="w-full rounded-xl border border-surface-200/70 bg-white px-3 py-2 text-sm text-surface-700 outline-none placeholder:text-surface-400"
         type="text"
         inputmode="numeric"
         pattern="[0-9]*"
@@ -217,7 +217,7 @@
 
       {#if menuView === 'favourites'}
         {#if favouriteSongs.length === 0}
-          <p class="rounded-xl border border-surface-200/70 bg-white px-4 py-4 text-sm text-surface-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-300">
+          <p class="rounded-xl border border-surface-200/70 bg-white px-4 py-4 text-sm text-surface-500">
             {$t('app.no_favourites')}
           </p>
         {:else}
@@ -225,12 +225,12 @@
             {#each favouriteSongs as favSong (favSong.id + '-' + favSong.language)}
               <li>
                 <button
-                  class="w-full rounded-xl border border-surface-200/70 bg-white px-4 py-3 text-left text-sm font-semibold text-surface-700 transition hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200"
+                  class="w-full rounded-xl border border-surface-200/70 bg-white px-4 py-3 text-left text-sm font-semibold text-surface-700 transition hover:border-primary-400 hover:text-primary-500"
                   on:click={() => openSong(favSong)}
                   type="button"
                 >
-                  <span class="block text-base font-semibold text-surface-900 dark:text-surface-50">{favSong.title}</span>
-                  <span class="text-xs uppercase tracking-[0.28em] text-surface-500 dark:text-surface-400">
+                  <span class="block text-base font-semibold text-surface-900">{favSong.title}</span>
+                  <span class="text-xs uppercase tracking-[0.28em] text-surface-500">
                     {$t('app.page_label')} {favSong.page}
                   </span>
                 </button>
@@ -244,14 +244,14 @@
             {@const pages = pagesForGroup(group)}
             {#if pages.length}
               <div class="space-y-2">
-                <p class="text-xs font-semibold uppercase tracking-[0.28em] text-surface-500 dark:text-surface-400">{group.label}</p>
+                <p class="text-xs font-semibold uppercase tracking-[0.28em] text-surface-500">{group.label}</p>
                 <div class="flex flex-wrap gap-2">
                   {#each pages as pageNumber}
                     <button
                       class={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
                         pageFilter === pageNumber
                           ? 'border-transparent bg-primary-500 text-white shadow-sm'
-                          : 'border-surface-200/70 bg-white text-surface-600 hover:border-primary-400 hover:text-primary-500 dark:border-surface-700 dark:bg-surface-800/80 dark:text-surface-200'
+                          : 'border-surface-200/70 bg-white text-surface-600 hover:border-primary-400 hover:text-primary-500'
                       }`}
                       type="button"
                       on:click={() => handlePageSelect(pageNumber)}
@@ -276,7 +276,7 @@
   </div>
 
   {#if filteredSongs.length === 0}
-    <div class="rounded-2xl border border-dashed border-surface-200/70 bg-white/70 px-6 py-12 text-center text-sm text-surface-500 dark:border-surface-700 dark:bg-surface-900/70 dark:text-surface-300">
+    <div class="rounded-2xl border border-dashed border-surface-200/70 bg-white/70 px-6 py-12 text-center text-sm text-surface-500">
       {$t('app.empty_state')}
     </div>
   {:else}

--- a/src/routes/song/[id]/+page.svelte
+++ b/src/routes/song/[id]/+page.svelte
@@ -66,7 +66,7 @@
   <div class="py-20 text-center text-sm text-[rgb(var(--text-secondary))]">{$t('app.syncing')}</div>
 {:else if song}
   <article
-    class="relative mx-auto max-w-4xl space-y-7 overflow-hidden rounded-2xl border border-primary-500/20 bg-white/90 p-5 shadow-2xl backdrop-blur-xl dark:border-surface-700/40 dark:bg-surface-900/80 sm:space-y-8 sm:rounded-[2.5rem] sm:p-8 lg:p-10"
+    class="relative mx-auto max-w-4xl space-y-7 overflow-hidden rounded-2xl border border-primary-500/20 bg-white/90 p-5 shadow-2xl backdrop-blur-xl sm:space-y-8 sm:rounded-[2.5rem] sm:p-8 lg:p-10"
   >
     <div class="pointer-events-none absolute inset-0 -z-10">
       <div class="absolute -top-24 left-10 h-48 w-48 rounded-full bg-primary-500/15 blur-[120px]"></div>
@@ -77,14 +77,14 @@
       <div class="flex flex-1 flex-wrap items-center justify-between gap-3">
         <div class="flex flex-wrap items-center gap-2.5">
           <button
-            class="inline-flex items-center gap-2 rounded-full border border-primary-500/20 bg-white/80 px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.2em] text-primary-500 transition hover:-translate-y-0.5 hover:border-primary-500 hover:text-primary-500 dark:border-surface-700/40 dark:bg-surface-900/70"
+            class="inline-flex items-center gap-2 rounded-full border border-primary-500/20 bg-white/80 px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.2em] text-primary-500 transition hover:-translate-y-0.5 hover:border-primary-500 hover:text-primary-500"
             type="button"
             on:click={goBack}
           >
             {$t('app.back_action')}
           </button>
           <button
-            class="inline-flex items-center gap-2 rounded-full border border-primary-500/20 bg-white/80 px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.2em] text-primary-500 transition hover:-translate-y-0.5 hover:border-primary-500 hover:text-primary-500 dark:border-surface-700/40 dark:bg-surface-900/70"
+            class="inline-flex items-center gap-2 rounded-full border border-primary-500/20 bg-white/80 px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.2em] text-primary-500 transition hover:-translate-y-0.5 hover:border-primary-500 hover:text-primary-500"
             type="button"
             on:click={() => goto('/')}
           >
@@ -95,7 +95,7 @@
           class={`inline-flex items-center justify-center gap-2 rounded-full px-4 py-1.5 text-sm font-semibold transition ${
             $favourites.includes(favouriteKey)
               ? 'bg-gradient-to-r from-primary-500 to-secondary-400 text-white shadow-lg'
-              : 'border border-primary-500/25 bg-white/70 text-surface-600 hover:border-primary-500 hover:text-primary-500 dark:border-surface-700/40 dark:bg-surface-900/70 dark:text-surface-200'
+              : 'border border-primary-500/25 bg-white/70 text-surface-600 hover:border-primary-500 hover:text-primary-500'
           }`}
           type="button"
           aria-pressed={$favourites.includes(favouriteKey)}
@@ -107,21 +107,21 @@
 
       <div class="space-y-3">
         <div class="space-y-2">
-          <h1 class="text-balance text-2xl font-semibold text-surface-900 dark:text-surface-50 sm:text-3xl lg:text-4xl">{song.title}</h1>
+          <h1 class="text-balance text-2xl font-semibold text-surface-900 sm:text-3xl lg:text-4xl">{song.title}</h1>
           {#if lastUpdatedLabel}
             <p class="text-[11px] uppercase tracking-[0.2em] text-primary-400/80">
               {$t('app.updated_label')}: {lastUpdatedLabel}
             </p>
           {/if}
         </div>
-        <div class="flex flex-wrap justify-center gap-2 text-xs text-surface-500 dark:text-surface-300 lg:justify-start">
+        <div class="flex flex-wrap justify-center gap-2 text-xs text-surface-500 lg:justify-start">
           <span class="rounded-full bg-primary-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-primary-500">
             {$t('app.page_label')} {song.page}
           </span>
-          <span class="rounded-full bg-white/80 px-3 py-1 text-[11px] text-surface-600 dark:bg-surface-900/70 dark:text-surface-200">
+          <span class="rounded-full bg-white/80 px-3 py-1 text-[11px] text-surface-600">
             {$t('app.source_label')} {song.source}
           </span>
-          <span class="rounded-full bg-white/80 px-3 py-1 text-[11px] text-surface-600 dark:bg-surface-900/70 dark:text-surface-200">
+          <span class="rounded-full bg-white/80 px-3 py-1 text-[11px] text-surface-600">
             {$t('app.external_index')} {song.externalIndex}
           </span>
         </div>
@@ -136,7 +136,7 @@
           class={`inline-flex items-center justify-center gap-2 rounded-full px-4 py-1.5 text-sm font-semibold transition ${
             activeViewMode === 'basic'
               ? 'bg-gradient-to-r from-primary-500 to-secondary-400 text-white shadow-lg'
-              : 'border border-primary-500/20 bg-white/70 text-surface-600 dark:border-surface-700/40 dark:bg-surface-800/70 dark:text-surface-200'
+              : 'border border-primary-500/20 bg-white/70 text-surface-600'
           }`}
           type="button"
           role="tab"
@@ -151,7 +151,7 @@
           class={`inline-flex items-center justify-center gap-2 rounded-full px-4 py-1.5 text-sm font-semibold transition ${
             activeViewMode === 'chords'
               ? 'bg-gradient-to-r from-primary-500 to-secondary-400 text-white shadow-lg'
-              : 'border border-primary-500/20 bg-white/70 text-surface-600 dark:border-surface-700/40 dark:bg-surface-800/70 dark:text-surface-200'
+              : 'border border-primary-500/20 bg-white/70 text-surface-600'
           }`}
           type="button"
           role="tab"
@@ -166,7 +166,7 @@
     </header>
 
     <section
-      class={`relative space-y-3 rounded-xl border border-primary-500/10 bg-white/80 p-4 text-left text-sm leading-relaxed shadow-inner dark:border-surface-700/40 dark:bg-surface-900/60 sm:rounded-2xl sm:p-6 sm:text-base ${
+      class={`relative space-y-3 rounded-xl border border-primary-500/10 bg-white/80 p-4 text-left text-sm leading-relaxed shadow-inner sm:rounded-2xl sm:p-6 sm:text-base ${
         activeViewMode === 'chords' ? 'lg:grid lg:grid-cols-[160px,1fr] lg:gap-6 lg:space-y-0' : ''
       }`}
     >
@@ -179,7 +179,7 @@
                 : item.alignment === 'RIGHT'
                 ? 'text-right'
                 : 'text-left'
-            } ${item.isBold ? 'font-semibold' : ''} ${item.isItalics ? 'italic' : ''} text-surface-700 dark:text-surface-200`}
+            } ${item.isBold ? 'font-semibold' : ''} ${item.isItalics ? 'italic' : ''} text-surface-700`}
           >
             {#if activeViewMode === 'chords' && item.type === 'CHORD'}
               <span class="text-[11px] font-semibold uppercase tracking-[0.2em] text-primary-400/80">CHORDS</span>


### PR DESCRIPTION
## Summary
- replace the header theme switcher with a segmented language toggle and light-only styling
- simplify list and song detail layouts to remove dark variants and keep filter controls on a single row
- drop theme-specific translations and enforce the light palette across the app shell and components

## Testing
- `npm run check` *(fails: missing optional dev dependency @sveltejs/adapter-static in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da7897a2f08327b8cfb2d3663361ac