### PR TITLE
Refresh theme selector and enable global search overlay

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -17,16 +17,17 @@
 		color-scheme: dark;
 	}
 
-	body {
-		font-family:
-			Inter,
-			'SF Pro Display',
-			-apple-system,
-			BlinkMacSystemFont,
-			'Segoe UI',
-			sans-serif;
-		@apply min-h-screen bg-surface-50 text-surface-900 antialiased transition-colors duration-500;
-	}
+        body {
+                font-family:
+                        Inter,
+                        'SF Pro Display',
+                        -apple-system,
+                        BlinkMacSystemFont,
+                        'Segoe UI',
+                        sans-serif;
+                color: rgb(var(--on-surface));
+                @apply min-h-screen bg-surface-50 antialiased transition-colors duration-500;
+        }
 
 	body.is-lenis {
 		overflow: hidden;
@@ -83,16 +84,32 @@
 		position: relative;
 	}
 
-	.gradient-border::before {
-		content: '';
-		position: absolute;
-		inset: -1px;
-		border-radius: inherit;
-		background: linear-gradient(130deg, rgba(129, 140, 248, 0.8), rgba(56, 189, 248, 0.7));
-		mask:
-			linear-gradient(#fff, #fff) padding-box,
-			linear-gradient(#fff, #fff);
-		mask-composite: exclude;
-		pointer-events: none;
-	}
+        .gradient-border::before {
+                content: '';
+                position: absolute;
+                inset: -1px;
+                border-radius: inherit;
+                background: linear-gradient(130deg, rgba(129, 140, 248, 0.8), rgba(56, 189, 248, 0.7));
+                mask:
+                        linear-gradient(#fff, #fff) padding-box,
+                        linear-gradient(#fff, #fff);
+                mask-composite: exclude;
+                pointer-events: none;
+        }
+
+        .text-on-surface {
+                color: rgb(var(--on-surface));
+        }
+
+        .text-on-surface-soft {
+                color: rgb(var(--on-surface) / 0.75);
+        }
+
+        .text-on-surface-muted {
+                color: rgb(var(--on-surface) / 0.6);
+        }
+
+        .text-on-surface-subtle {
+                color: rgb(var(--on-surface) / 0.45);
+        }
 }

--- a/src/lib/components/layout/AppHeader.svelte
+++ b/src/lib/components/layout/AppHeader.svelte
@@ -4,9 +4,10 @@
 	import { language } from '$lib/stores/preferences';
 	import { isSyncing, lastSynced } from '$lib/stores/songStore';
 	import { derived } from 'svelte/store';
-	import { Languages, Search } from 'lucide-svelte';
-	import type { SongLanguage } from '$lib/types/song';
-	import ThemeSelector from '$lib/components/preferences/ThemeSelector.svelte';
+        import { Languages, Search } from 'lucide-svelte';
+        import type { SongLanguage } from '$lib/types/song';
+        import ThemeSelector from '$lib/components/preferences/ThemeSelector.svelte';
+        import { openSearchOverlay } from '$lib/stores/ui';
 
 	type LanguageOption = {
 		code: SongLanguage;
@@ -27,16 +28,19 @@
 		language.set(code);
 	}
 
-	function focusSearch() {
-		if (!browser) return;
+        function focusSearch() {
+                if (!browser) return;
 
-		const searchField = document.getElementById('song-search') as HTMLInputElement | null;
-		if (searchField) {
-			searchField.scrollIntoView({ behavior: 'smooth', block: 'center' });
-			searchField.focus({ preventScroll: true });
-			searchField.select();
-		}
-	}
+                const searchField = document.getElementById('song-search') as HTMLInputElement | null;
+                if (searchField) {
+                        searchField.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                        searchField.focus({ preventScroll: true });
+                        searchField.select();
+                        return;
+                }
+
+                openSearchOverlay();
+        }
 </script>
 
 <section class="pt-6 sm:pt-10 lg:pt-12">
@@ -49,9 +53,9 @@
 					<p class="text-[11px] font-semibold uppercase tracking-[0.22em] text-primary-500">
 						{$t('app.brand_global')}
 					</p>
-					<h1 class="text-balance text-2xl font-semibold text-surface-900 sm:text-3xl lg:text-4xl">
-						{$t('app.title')}
-					</h1>
+                                        <h1 class="text-balance text-2xl font-semibold text-on-surface sm:text-3xl lg:text-4xl">
+                                                {$t('app.title')}
+                                        </h1>
 					<!-- <p class="max-w-2xl text-sm leading-relaxed text-surface-600">
             {$t('app.tagline')}
           </p> -->
@@ -60,21 +64,21 @@
 					class="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end sm:gap-4"
 				>
 					<ThemeSelector />
-					<div
-						class="flex items-center gap-3 rounded-full border border-surface-200/70 bg-surface-100/70 px-3 py-1.5 text-xs font-semibold text-surface-600 shadow-sm"
-					>
-						<Languages class="h-4 w-4 text-primary-500" />
-						<span class="hidden text-[11px] uppercase tracking-[0.18em] text-surface-500 sm:inline">
-							{$t('app.language_label')}
-						</span>
+                                        <div
+                                                class="flex items-center gap-3 rounded-full border border-surface-200/70 bg-surface-100/70 px-3 py-1.5 text-xs font-semibold text-on-surface-soft shadow-sm"
+                                        >
+                                                <Languages class="h-4 w-4 text-primary-500" />
+                                                <span class="hidden text-[11px] uppercase tracking-[0.18em] text-on-surface-subtle sm:inline">
+                                                        {$t('app.language_label')}
+                                                </span>
 						<div class="grid grid-cols-2 gap-1 rounded-full bg-surface-50/80 p-1 shadow-inner">
 							{#each languageOptions as option}
 								<button
 									class={`rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] transition ${
 										$language === option.code
 											? 'bg-primary-500 text-white shadow'
-											: 'text-surface-500 hover:text-primary-500'
-									}`}
+                                                                                        : 'text-on-surface-subtle hover:text-primary-500'
+                                                                        }`}
 									type="button"
 									aria-pressed={$language === option.code}
 									on:click={() => setLanguage(option.code)}
@@ -96,21 +100,21 @@
 					<Search class="h-4 w-4" />
 					{$t('app.search_placeholder')}
 				</button>
-				<div class="flex flex-col gap-2 text-xs text-surface-600 sm:flex-row sm:items-center">
-					<p
-						class="flex items-center gap-2 rounded-full border border-surface-200/70 bg-surface-100/70 px-3 py-1.5 uppercase tracking-[0.18em]"
-					>
-						<span class="text-surface-900">{$syncStatus}</span>
-					</p>
-					<p
-						class="flex items-center gap-2 rounded-full border border-surface-200/70 bg-surface-100/70 px-3 py-1.5 uppercase tracking-[0.18em]"
-					>
-						<span class="text-surface-500">{$t('app.last_synced')}</span>
-						<span class="text-surface-900"
-							>{$lastSynced ? new Date($lastSynced).toLocaleString() : '—'}</span
-						>
-					</p>
-				</div>
+                                <div class="flex flex-col gap-2 text-xs text-on-surface-soft sm:flex-row sm:items-center">
+                                        <p
+                                                class="flex items-center gap-2 rounded-full border border-surface-200/70 bg-surface-100/70 px-3 py-1.5 uppercase tracking-[0.18em]"
+                                        >
+                                                <span class="text-on-surface">{$syncStatus}</span>
+                                        </p>
+                                        <p
+                                                class="flex items-center gap-2 rounded-full border border-surface-200/70 bg-surface-100/70 px-3 py-1.5 uppercase tracking-[0.18em]"
+                                        >
+                                                <span class="text-on-surface-subtle">{$t('app.last_synced')}</span>
+                                                <span class="text-on-surface"
+                                                        >{$lastSynced ? new Date($lastSynced).toLocaleString() : '—'}</span
+                                                >
+                                        </p>
+                                </div>
 			</div>
 		</div>
 	</div>

--- a/src/lib/components/preferences/ThemeSelector.svelte
+++ b/src/lib/components/preferences/ThemeSelector.svelte
@@ -1,61 +1,71 @@
 <script lang="ts">
-	import { t } from 'svelte-i18n';
-	import { Palette } from 'lucide-svelte';
-	import { themeName } from '$lib/stores/preferences';
-	import { defaultTheme, themeOptions } from '$lib/config/themes';
+        import { t } from 'svelte-i18n';
+        import { Check, Palette } from 'lucide-svelte';
+        import { themeName } from '$lib/stores/preferences';
+        import { defaultTheme, themeOptions } from '$lib/config/themes';
 
-	let selectElement: HTMLSelectElement | null = null;
+        $: activeTheme = themeOptions.find((option) => option.id === $themeName) ?? defaultTheme;
 
-	$: activeTheme = themeOptions.find((option) => option.id === $themeName) ?? defaultTheme;
-	$: if (selectElement) {
-		selectElement.value = $themeName;
-	}
-
-	function handleChange(event: Event) {
-		const target = event.currentTarget as HTMLSelectElement | null;
-		if (!target) return;
-		themeName.set(target.value);
-	}
+        function selectTheme(themeId: string) {
+                themeName.set(themeId);
+        }
 </script>
 
 <div
-	class="group flex items-center gap-3 rounded-2xl border border-surface-200/70 bg-surface-50/80 px-4 py-2.5 text-xs font-semibold text-surface-600 shadow-sm backdrop-blur"
+        class="space-y-3 rounded-2xl border border-surface-200/70 bg-surface-50/80 px-4 py-3 text-xs font-semibold text-on-surface-soft shadow-sm backdrop-blur"
 >
-	<Palette
-		class="h-4 w-4 text-primary-500 transition group-hover:text-primary-400"
-		aria-hidden="true"
-	/>
-	<div class="flex flex-col gap-2">
-		<label class="text-[11px] uppercase tracking-[0.18em] text-surface-500" for="theme-select">
-			{$t('app.theme_label')}
-		</label>
-		<div class="flex items-center gap-3">
-			<div class="relative">
-				<select
-					id="theme-select"
-					class="appearance-none rounded-xl border border-surface-200/70 bg-surface-100/80 px-3 py-2 pr-8 text-xs font-semibold uppercase tracking-[0.2em] text-surface-700 shadow-sm outline-none transition focus:border-primary-300 focus:ring-2 focus:ring-primary-200/60"
-					bind:this={selectElement}
-					value={$themeName}
-					on:change={handleChange}
-				>
-					{#each themeOptions as option}
-						<option value={option.id}>{$t(`app.themes.${option.labelKey}`)}</option>
-					{/each}
-				</select>
-				<span
-					aria-hidden="true"
-					class="pointer-events-none absolute inset-y-0 right-2 flex items-center text-[10px] text-primary-400"
-				>
-					▼
-				</span>
-			</div>
-			<span
-				class="flex h-7 w-16 overflow-hidden rounded-full border border-surface-200/70 bg-surface-100 shadow-sm"
-			>
-				{#each activeTheme.preview as color}
-					<span class="flex-1" style={`background:${color}`}></span>
-				{/each}
-			</span>
-		</div>
-	</div>
+        <div class="flex items-center gap-3">
+                <span class="flex h-9 w-9 items-center justify-center rounded-full border border-primary-200/60 bg-primary-50/70 text-primary-500 shadow-sm">
+                        <Palette class="h-4 w-4" aria-hidden="true" />
+                </span>
+                <div>
+                        <p class="text-[11px] uppercase tracking-[0.18em] text-on-surface-subtle">
+                                {$t('app.theme_label')}
+                        </p>
+                        <p class="text-sm font-semibold text-on-surface">
+                                {$t(`app.themes.${activeTheme.labelKey}`)}
+                        </p>
+                </div>
+        </div>
+        <div class="grid gap-2 sm:grid-cols-2">
+                {#each themeOptions as option}
+                        {#key option.id}
+                                <button
+                                        class={`group/theme relative flex items-center gap-3 rounded-2xl border px-3.5 py-2.5 text-left transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-400 ${
+                                                option.id === $themeName
+                                                        ? 'border-primary-400 bg-primary-50/60 text-on-surface shadow-sm'
+                                                        : 'border-surface-200/70 bg-surface-100/60 text-on-surface-soft hover:border-primary-300 hover:text-primary-500'
+                                        }`}
+                                        type="button"
+                                        aria-pressed={option.id === $themeName}
+                                        on:click={() => selectTheme(option.id)}
+                                >
+                                        <span
+                                                class={`flex h-9 w-16 overflow-hidden rounded-full border shadow-inner ${
+                                                        option.id === $themeName
+                                                                ? 'border-primary-300'
+                                                                : 'border-surface-200/70'
+                                                }`}
+                                        >
+                                                {#each option.preview as color}
+                                                        <span class="flex-1" style={`background:${color}`}></span>
+                                                {/each}
+                                        </span>
+                                        <span class="flex flex-1 flex-col text-left">
+                                                <span class="text-sm font-semibold text-on-surface">
+                                                        {$t(`app.themes.${option.labelKey}`)}
+                                                </span>
+                                                <span class="text-[11px] uppercase tracking-[0.18em] text-on-surface-subtle">
+                                                        {$t(`app.theme_scheme.${option.scheme}`)}
+                                                </span>
+                                        </span>
+                                        {#if option.id === $themeName}
+                                                <span class="text-primary-500">
+                                                        <Check class="h-4 w-4" aria-hidden="true" />
+                                                </span>
+                                        {/if}
+                                </button>
+                        {/key}
+                {/each}
+        </div>
 </div>

--- a/src/lib/components/search/SearchOverlay.svelte
+++ b/src/lib/components/search/SearchOverlay.svelte
@@ -1,0 +1,161 @@
+<script lang="ts">
+        import { browser } from '$app/environment';
+        import { goto, afterNavigate } from '$app/navigation';
+        import { tick } from 'svelte';
+        import { t } from 'svelte-i18n';
+        import { Search, X } from 'lucide-svelte';
+        import { favourites, language } from '$lib/stores/preferences';
+        import { closeSearchOverlay, isSearchOverlayOpen } from '$lib/stores/ui';
+        import { filterSongs, searchableSongs } from '$lib/stores/songStore';
+        import type { Song } from '$lib/types/song';
+
+        let query = '';
+        let inputRef: HTMLInputElement | null = null;
+        let panelRef: HTMLDivElement | null = null;
+
+        afterNavigate(() => {
+                closeSearchOverlay();
+        });
+
+        function resetState() {
+                query = '';
+        }
+
+        function handleClose() {
+                closeSearchOverlay();
+        }
+
+        function handleBackdropClick(event: MouseEvent) {
+                if (event.target === event.currentTarget) {
+                        handleClose();
+                }
+        }
+
+        function handleKeydown(event: KeyboardEvent) {
+                if (event.key === 'Escape') {
+                        event.preventDefault();
+                        handleClose();
+                }
+        }
+
+        async function focusInput() {
+                await tick();
+                if (inputRef) {
+                        inputRef.focus();
+                        inputRef.select();
+                }
+                if (panelRef) {
+                        panelRef.scrollTop = 0;
+                }
+        }
+
+        function handleSelect(song: Song) {
+                handleClose();
+                goto(`/song/${song.id}?lang=${song.language}`);
+        }
+
+        $: if (!$isSearchOverlayOpen) {
+                resetState();
+        }
+
+        $: if ($isSearchOverlayOpen) {
+                focusInput();
+                if (browser) {
+                        document.body.classList.add('overflow-hidden');
+                }
+        } else if (browser) {
+                document.body.classList.remove('overflow-hidden');
+        }
+
+        $: results = filterSongs(
+                $searchableSongs,
+                query,
+                $language,
+                false,
+                $favourites,
+                null,
+                'alpha'
+        ).slice(0, 10);
+
+        $: hasQuery = query.trim().length > 0;
+</script>
+
+{#if $isSearchOverlayOpen}
+        <div
+                class="fixed inset-0 z-50 flex items-start justify-center bg-surface-900/50 px-4 py-16 backdrop-blur"
+                role="presentation"
+                on:click={handleBackdropClick}
+                on:keydown={handleKeydown}
+        >
+                <div
+                        class="w-full max-w-xl rounded-3xl border border-surface-200/70 bg-surface-50/95 p-5 shadow-2xl"
+                        role="dialog"
+                        aria-modal="true"
+                        tabindex="-1"
+                        bind:this={panelRef}
+                >
+                        <div class="flex items-start justify-between gap-3">
+                                <div class="flex-1">
+                                        <label
+                                                class="text-[11px] font-semibold uppercase tracking-[0.2em] text-on-surface-subtle"
+                                                for="search-overlay-input"
+                                        >
+                                                {$t('app.search_placeholder')}
+                                        </label>
+                                        <div
+                                                class="mt-2 flex items-center gap-2.5 rounded-xl border border-surface-200/60 bg-surface-100/70 px-3.5 py-2.5 shadow-inner"
+                                        >
+                                                <Search class="h-4 w-4 text-primary-500" aria-hidden="true" />
+                                                <input
+                                                        id="search-overlay-input"
+                                                        class="w-full bg-transparent text-sm text-on-surface outline-none placeholder:text-on-surface-muted sm:text-base"
+                                                        type="search"
+                                                        autocomplete="off"
+                                                        spellcheck={false}
+                                                        bind:value={query}
+                                                        bind:this={inputRef}
+                                                />
+                                        </div>
+                                </div>
+                                <button
+                                        class="inline-flex shrink-0 items-center justify-center rounded-full border border-surface-200/70 bg-surface-100/70 p-2 text-on-surface-soft transition hover:border-primary-300 hover:text-primary-400"
+                                        type="button"
+                                        on:click={handleClose}
+                                >
+                                        <span class="sr-only">{$t('app.clear_query')}</span>
+                                        <X class="h-4 w-4" aria-hidden="true" />
+                                </button>
+                        </div>
+
+                        {#if results.length}
+                                <div class="mt-5 space-y-2">
+                                        {#each results as song (song.id + song.language)}
+                                                <button
+                                                        class="flex w-full items-center justify-between gap-3 rounded-2xl border border-surface-200/70 bg-surface-50/80 px-4 py-3 text-left text-sm font-medium text-on-surface transition hover:border-primary-400 hover:text-primary-500"
+                                                        type="button"
+                                                        on:click={() => handleSelect(song)}
+                                                >
+                                                        <div>
+                                                                <p class="font-semibold">{song.title}</p>
+                                                                <p class="text-xs text-on-surface-muted">
+                                                                        {$t('app.page_label')} {song.page} · {song.source}
+                                                                </p>
+                                                        </div>
+                                                        <span class="text-[11px] font-semibold uppercase tracking-[0.2em] text-primary-400/80">
+                                                                {$t('app.view_song')}
+                                                        </span>
+                                                </button>
+                                        {/each}
+                                </div>
+                        {:else if hasQuery}
+                                <p class="mt-6 text-center text-sm text-on-surface-muted">
+                                        {$t('app.empty_state')}
+                                </p>
+                        {:else}
+                                <p class="mt-6 text-center text-sm text-on-surface-muted">
+                                        {$t('app.search_hint')}
+                                </p>
+                        {/if}
+                </div>
+        </div>
+{/if}

--- a/src/lib/components/song/SongCard.svelte
+++ b/src/lib/components/song/SongCard.svelte
@@ -100,41 +100,41 @@
 				<div class="flex flex-col gap-3.5 lg:flex-row lg:items-start lg:justify-between">
 					<div class="space-y-3">
 						<div class="space-y-2">
-							<h3 class="text-lg font-semibold text-surface-900 sm:text-xl">{song.title}</h3>
-							{#if lastUpdatedLabel}
-								<p class="text-xs text-surface-500">
-									{$t('app.updated_label')}: {lastUpdatedLabel}
-								</p>
-							{/if}
-						</div>
-						<div class="flex flex-wrap items-center gap-2 text-xs text-surface-500">
-							<span
-								class="inline-flex items-center gap-2 rounded-full border border-surface-200/60 bg-surface-100/70 px-3 py-1 font-medium text-surface-700"
-							>
-								{$t('app.page_label')}
-								{song.page}
-							</span>
-							<span
-								class="inline-flex items-center gap-2 rounded-full border border-surface-200/60 bg-surface-100/70 px-3 py-1 text-surface-600"
-							>
-								{$t('app.source_label')}
-								{song.source}
-							</span>
-							<span
-								class="inline-flex items-center gap-2 rounded-full border border-surface-200/60 bg-surface-100/70 px-3 py-1 text-surface-600"
-							>
-								{$t('app.external_index')}
-								{song.externalIndex}
-							</span>
-						</div>
+                                                        <h3 class="text-lg font-semibold text-on-surface sm:text-xl">{song.title}</h3>
+                                                        {#if lastUpdatedLabel}
+                                                                <p class="text-xs text-on-surface-subtle">
+                                                                        {$t('app.updated_label')}: {lastUpdatedLabel}
+                                                                </p>
+                                                        {/if}
+                                                </div>
+                                                <div class="flex flex-wrap items-center gap-2 text-xs text-on-surface-subtle">
+                                                        <span
+                                                                class="inline-flex items-center gap-2 rounded-full border border-surface-200/60 bg-surface-100/70 px-3 py-1 font-medium text-on-surface"
+                                                        >
+                                                                {$t('app.page_label')}
+                                                                {song.page}
+                                                        </span>
+                                                        <span
+                                                                class="inline-flex items-center gap-2 rounded-full border border-surface-200/60 bg-surface-100/70 px-3 py-1 text-on-surface-soft"
+                                                        >
+                                                                {$t('app.source_label')}
+                                                                {song.source}
+                                                        </span>
+                                                        <span
+                                                                class="inline-flex items-center gap-2 rounded-full border border-surface-200/60 bg-surface-100/70 px-3 py-1 text-on-surface-soft"
+                                                        >
+                                                                {$t('app.external_index')}
+                                                                {song.externalIndex}
+                                                        </span>
+                                                </div>
 					</div>
 					<div class="flex flex-wrap justify-end gap-2 text-sm">
 						<button
 							class={`inline-flex items-center gap-2 rounded-full border border-surface-200/60 bg-surface-100/70 px-3.5 py-1.5 text-sm font-medium transition hover:border-primary-400 hover:text-primary-500 ${
-								isFavourite
-									? 'bg-primary-500/10 text-primary-600 shadow-inner shadow-primary-500/20'
-									: 'text-surface-700'
-							}`}
+                                                                isFavourite
+                                                                        ? 'bg-primary-500/10 text-primary-600 shadow-inner shadow-primary-500/20'
+                                                                        : 'text-on-surface'
+                                                        }`}
 							on:click={() => dispatch('toggleFavourite', `${song.id}-${song.language}`)}
 							type="button"
 						>
@@ -188,7 +188,7 @@
                     style:transition={prefersReducedMotion ? 'none' : 'transform 420ms cubic-bezier(0.22, 1, 0.36, 1)'}
                   />
                 </span>
-                <span class="text-sm font-semibold text-surface-700">{densityPercentage}%</span>
+                <span class="text-sm font-semibold text-on-surface">{densityPercentage}%</span>
               </div>
             </div>
             <p class="text-xs text-surface-500">
@@ -197,7 +197,7 @@
           </div>
         </div> -->
 
-				<div class="space-y-3 text-sm leading-relaxed text-surface-700">
+                            <div class="space-y-3 text-sm leading-relaxed text-on-surface">
 					{#each previewItems as item}
 						<p
 							class={`whitespace-pre-line ${alignmentClass(item.alignment)} ${item.isBold ? 'font-semibold' : ''} ${item.isItalics ? 'italic' : ''}`}
@@ -218,7 +218,7 @@
 				</div>
 
 				{#if remainingItems.length && expanded}
-					<div class="space-y-3 text-sm leading-relaxed text-surface-700" transition:fade>
+                                    <div class="space-y-3 text-sm leading-relaxed text-on-surface" transition:fade>
 						{#each remainingItems as item}
 							<p
 								class={`whitespace-pre-line ${alignmentClass(item.alignment)} ${item.isBold ? 'font-semibold' : ''} ${item.isItalics ? 'italic' : ''}`}

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -4,14 +4,18 @@
 		"tagline": "Church worship songs at your fingertips",
 		"search_placeholder": "Search by title, lyric, page or index…",
 		"language_label": "Language",
-		"theme_label": "Theme",
-		"themes": {
-			"dawn": "Dawn Ember",
-			"meadow": "Meadow Breeze",
-			"aurora": "Aurora Glow",
-			"dusk": "Dusk Horizon",
-			"midnight": "Midnight Echo"
-		},
+                "theme_label": "Theme",
+                "themes": {
+                        "dawn": "Warm Light",
+                        "meadow": "Forest",
+                        "aurora": "Indigo",
+                        "dusk": "Twilight",
+                        "midnight": "Midnight"
+                },
+                "theme_scheme": {
+                        "light": "Light",
+                        "dark": "Dark"
+                },
 		"view": {
 			"basic": "Lyrics",
 			"chords": "Chords view"

--- a/src/lib/locales/pl.json
+++ b/src/lib/locales/pl.json
@@ -4,14 +4,18 @@
 		"tagline": "Zborowy śpiewnik zawsze pod ręką",
 		"search_placeholder": "Szukaj po tytule, tekście, stronie lub indeksie…",
 		"language_label": "Język",
-		"theme_label": "Motyw",
-		"themes": {
-			"dawn": "Świt",
-			"meadow": "Łąkowy Wiatr",
-			"aurora": "Zorza",
-			"dusk": "Zmierzch",
-			"midnight": "Północna Cisza"
-		},
+                "theme_label": "Motyw",
+                "themes": {
+                        "dawn": "Ciepłe światło",
+                        "meadow": "Leśny",
+                        "aurora": "Indygo",
+                        "dusk": "Zmierzch",
+                        "midnight": "Północ"
+                },
+                "theme_scheme": {
+                        "light": "Jasny",
+                        "dark": "Ciemny"
+                },
 		"view": {
 			"basic": "Tekst",
 			"chords": "Akordy"

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -1,0 +1,15 @@
+import { writable } from 'svelte/store';
+
+const searchOverlay = writable(false);
+
+export const isSearchOverlayOpen = {
+        subscribe: searchOverlay.subscribe
+};
+
+export function openSearchOverlay() {
+        searchOverlay.set(true);
+}
+
+export function closeSearchOverlay() {
+        searchOverlay.set(false);
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,7 +4,8 @@
 	import { onDestroy, onMount } from 'svelte';
 	import { addMessages, init, locale as i18nLocale } from 'svelte-i18n';
 	import { get } from 'svelte/store';
-	import AppHeader from '$lib/components/layout/AppHeader.svelte';
+        import AppHeader from '$lib/components/layout/AppHeader.svelte';
+        import SearchOverlay from '$lib/components/search/SearchOverlay.svelte';
 	import { loadSongs } from '$lib/stores/songStore';
 	import { language } from '$lib/stores/preferences';
 	import pl from '$lib/locales/pl.json';
@@ -59,7 +60,7 @@
 	});
 </script>
 
-<div class="relative min-h-screen overflow-hidden text-surface-900">
+<div class="relative min-h-screen overflow-hidden text-on-surface">
 	<div class="pointer-events-none absolute inset-0 -z-10">
 		<div
 			class="absolute inset-0 bg-gradient-to-b from-surface-50 via-surface-100/80 to-surface-50"
@@ -74,25 +75,26 @@
 	<div
 		class="relative mx-auto flex min-h-screen w-full max-w-5xl flex-col px-3 pb-12 sm:px-5 lg:max-w-6xl lg:px-8"
 	>
-		<AppHeader />
-		<main class="flex-1 py-6 sm:py-8 lg:py-10">
-			<slot />
-		</main>
-		<footer class="mt-10 border-t border-surface-200/60 py-5 text-xs text-surface-500 sm:text-sm">
-			<p class="font-semibold uppercase tracking-[0.18em] text-[11px] text-primary-500/80">
-				Wspólnota Biblijna KWCh
-			</p>
-			<p class="mt-2 max-w-xl leading-relaxed">
-				<a
-					class="font-semibold text-primary-500 underline-offset-4 transition hover:text-primary-400 hover:underline"
-					href="https://kwch.wroclaw.pl/"
-					rel="noreferrer"
-					target="_blank"
-				>
-					kwch.wroclaw.pl
-				</a>
-				.
-			</p>
-		</footer>
-	</div>
+                <AppHeader />
+                <main class="flex-1 py-6 sm:py-8 lg:py-10">
+                        <slot />
+                </main>
+                <footer class="mt-10 border-t border-surface-200/60 py-5 text-xs text-on-surface-muted sm:text-sm">
+                        <p class="font-semibold uppercase tracking-[0.18em] text-[11px] text-primary-500/80">
+                                Wspólnota Biblijna KWCh
+                        </p>
+                        <p class="mt-2 max-w-xl leading-relaxed text-on-surface">
+                                <a
+                                        class="font-semibold text-primary-500 underline-offset-4 transition hover:text-primary-400 hover:underline"
+                                        href="https://kwch.wroclaw.pl/"
+                                        rel="noreferrer"
+                                        target="_blank"
+                                >
+                                        kwch.wroclaw.pl
+                                </a>
+                                .
+                        </p>
+                </footer>
+        </div>
+        <SearchOverlay />
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -110,12 +110,12 @@
 				class="flex items-center gap-2.5 rounded-xl border border-surface-200/60 bg-surface-100/70 px-3.5 py-2.5 shadow-inner"
 			>
 				<Search class="h-4 w-4 text-primary-500" />
-				<input
-					id="song-search"
-					class="w-full bg-transparent text-sm text-surface-800 outline-none placeholder:text-surface-400 sm:text-base"
-					type="search"
-					placeholder={$t('app.search_placeholder')}
-					bind:value={query}
+                                <input
+                                        id="song-search"
+                                        class="w-full bg-transparent text-sm text-on-surface outline-none placeholder:text-on-surface-muted sm:text-base"
+                                        type="search"
+                                        placeholder={$t('app.search_placeholder')}
+                                        bind:value={query}
 					bind:this={searchRef}
 				/>
 				{#if query}
@@ -131,16 +131,16 @@
 			<!-- <p class="text-xs text-surface-500">{$t('app.search_hint')}</p> -->
 		</div>
 
-		<div class="flex flex-wrap items-center gap-3 text-sm text-surface-600">
-			<span class="font-semibold text-surface-900">{filteredSongs.length}</span>
+                <div class="flex flex-wrap items-center gap-3 text-sm text-on-surface-soft">
+                        <span class="font-semibold text-on-surface">{filteredSongs.length}</span>
 			<span>/</span>
 			<span>{availableSongs.length}</span>
 			{#if pageFilter}
 				<span
-					class="rounded-full bg-primary-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-primary-500"
-				>
-					{$t('app.page_label')}
-					{pageFilter}
+                                        class="rounded-full bg-primary-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-primary-500"
+                                >
+                                        {$t('app.page_label')}
+                                        {pageFilter}
 				</span>
 			{/if}
 		</div>
@@ -226,26 +226,25 @@
 
 			{#if menuView === 'favourites'}
 				{#if favouriteSongs.length === 0}
-					<p
-						class="rounded-xl border border-surface-200/60 bg-surface-50/80 px-4 py-4 text-sm text-surface-500"
-					>
-						{$t('app.no_favourites')}
-					</p>
-				{:else}
-					<ul class="grid gap-3 sm:grid-cols-2">
-						{#each favouriteSongs as favSong (favSong.id + '-' + favSong.language)}
-							<li>
-								<button
-									class="w-full rounded-xl border border-surface-200/60 bg-surface-100/70 px-4 py-3 text-left text-sm font-semibold text-surface-700 transition hover:border-primary-400 hover:text-primary-500"
-									on:click={() => openSong(favSong)}
-									type="button"
-								>
-									<span class="block text-base font-semibold text-surface-900">{favSong.title}</span
-									>
-									<span class="text-xs uppercase tracking-[0.28em] text-surface-500">
-										{$t('app.page_label')}
-										{favSong.page}
-									</span>
+                                        <p
+                                                class="rounded-xl border border-surface-200/60 bg-surface-50/80 px-4 py-4 text-sm text-on-surface-subtle"
+                                        >
+                                                {$t('app.no_favourites')}
+                                        </p>
+                                {:else}
+                                        <ul class="grid gap-3 sm:grid-cols-2">
+                                                {#each favouriteSongs as favSong (favSong.id + '-' + favSong.language)}
+                                                        <li>
+                                                                <button
+                                                                        class="w-full rounded-xl border border-surface-200/60 bg-surface-100/70 px-4 py-3 text-left text-sm font-semibold text-on-surface transition hover:border-primary-400 hover:text-primary-500"
+                                                                        on:click={() => openSong(favSong)}
+                                                                        type="button"
+                                                                >
+                                                                        <span class="block text-base font-semibold text-on-surface">{favSong.title}</span>
+                                                                        <span class="text-xs uppercase tracking-[0.28em] text-on-surface-subtle">
+                                                                                {$t('app.page_label')}
+                                                                                {favSong.page}
+                                                                        </span>
 								</button>
 							</li>
 						{/each}

--- a/src/routes/song/[id]/+page.svelte
+++ b/src/routes/song/[id]/+page.svelte
@@ -117,30 +117,30 @@
 
 			<div class="space-y-3">
 				<div class="space-y-2">
-					<h1 class="text-balance text-2xl font-semibold text-surface-900 sm:text-3xl lg:text-4xl">
-						{song.title}
-					</h1>
+                                        <h1 class="text-balance text-2xl font-semibold text-on-surface sm:text-3xl lg:text-4xl">
+                                                {song.title}
+                                        </h1>
 					{#if lastUpdatedLabel}
 						<p class="text-[11px] uppercase tracking-[0.2em] text-primary-400/80">
 							{$t('app.updated_label')}: {lastUpdatedLabel}
 						</p>
 					{/if}
 				</div>
-				<div class="flex flex-wrap justify-center gap-2 text-xs text-surface-500 lg:justify-start">
+                                <div class="flex flex-wrap justify-center gap-2 text-xs text-on-surface-subtle lg:justify-start">
 					<span
 						class="rounded-full bg-primary-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-primary-500"
 					>
 						{$t('app.page_label')}
 						{song.page}
 					</span>
-					<span class="rounded-full bg-surface-100/70 px-3 py-1 text-[11px] text-surface-600">
-						{$t('app.source_label')}
-						{song.source}
-					</span>
-					<span class="rounded-full bg-surface-100/70 px-3 py-1 text-[11px] text-surface-600">
-						{$t('app.external_index')}
-						{song.externalIndex}
-					</span>
+                                        <span class="rounded-full bg-surface-100/70 px-3 py-1 text-[11px] text-on-surface-soft">
+                                                {$t('app.source_label')}
+                                                {song.source}
+                                        </span>
+                                        <span class="rounded-full bg-surface-100/70 px-3 py-1 text-[11px] text-on-surface-soft">
+                                                {$t('app.external_index')}
+                                                {song.externalIndex}
+                                        </span>
 				</div>
 			</div>
 
@@ -196,7 +196,7 @@
 								: item.alignment === 'RIGHT'
 									? 'text-right'
 									: 'text-left'
-						} ${item.isBold ? 'font-semibold' : ''} ${item.isItalics ? 'italic' : ''} text-surface-700`}
+                                                } ${item.isBold ? 'font-semibold' : ''} ${item.isItalics ? 'italic' : ''} text-on-surface`}
 					>
 						{#if activeViewMode === 'chords' && item.type === 'CHORD'}
 							<span class="text-[11px] font-semibold uppercase tracking-[0.2em] text-primary-400/80"


### PR DESCRIPTION
## Summary
- redesign the theme selector into preview cards, update theme names, and add light/dark scheme labels
- add reusable on-surface text utilities and apply them across key layouts and song views so theme changes affect text color
- implement a global search overlay triggered from the header when the inline search field is unavailable

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68db1335039c8327bffb6b312249b252