### PR TITLE
Revamp theme system and modernize UI

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -2,315 +2,200 @@
 @import 'tailwindcss';
 
 @theme {
-        /* default theme tokens - songbook-dawn */
-        --color-surface-50: 255 248 244;
-        --color-surface-100: 255 239 226;
-        --color-surface-200: 254 223 200;
-        --color-surface-300: 253 206 170;
-        --color-surface-400: 251 182 140;
-        --color-surface-500: 246 150 104;
-        --color-surface-600: 229 125 82;
-        --color-surface-700: 201 96 62;
-        --color-surface-800: 163 72 47;
-        --color-surface-900: 120 52 34;
+        /* default theme tokens - songbook-lumen */
+        --color-surface-50: 255 249 243;
+        --color-surface-100: 253 240 230;
+        --color-surface-200: 249 225 210;
+        --color-surface-300: 242 203 184;
+        --color-surface-400: 230 177 153;
+        --color-surface-500: 213 146 118;
+        --color-surface-600: 184 114 93;
+        --color-surface-700: 151 88 74;
+        --color-surface-800: 117 66 59;
+        --color-surface-900: 82 47 44;
 
-        --color-primary-50: 255 247 237;
-        --color-primary-100: 255 237 213;
-        --color-primary-200: 254 215 170;
-        --color-primary-300: 253 186 116;
-        --color-primary-400: 251 146 60;
-        --color-primary-500: 249 115 22;
-        --color-primary-600: 234 88 12;
-        --color-primary-700: 194 65 12;
-        --color-primary-800: 154 52 18;
-        --color-primary-900: 124 45 18;
+        --color-primary-50: 255 240 252;
+        --color-primary-100: 252 231 247;
+        --color-primary-200: 249 214 239;
+        --color-primary-300: 244 185 226;
+        --color-primary-400: 236 140 204;
+        --color-primary-500: 221 91 180;
+        --color-primary-600: 196 64 164;
+        --color-primary-700: 165 52 143;
+        --color-primary-800: 133 46 120;
+        --color-primary-900: 103 38 95;
 
-        --color-secondary-50: 253 244 255;
-        --color-secondary-100: 250 232 255;
-        --color-secondary-200: 245 208 254;
-        --color-secondary-300: 240 171 252;
-        --color-secondary-400: 232 121 249;
-        --color-secondary-500: 217 70 239;
-        --color-secondary-600: 192 38 211;
-        --color-secondary-700: 162 28 175;
-        --color-secondary-800: 134 25 143;
-        --color-secondary-900: 112 26 117;
+        --color-secondary-50: 239 244 255;
+        --color-secondary-100: 224 232 255;
+        --color-secondary-200: 202 215 255;
+        --color-secondary-300: 178 197 255;
+        --color-secondary-400: 146 173 255;
+        --color-secondary-500: 109 143 255;
+        --color-secondary-600: 82 116 245;
+        --color-secondary-700: 63 92 220;
+        --color-secondary-800: 51 74 185;
+        --color-secondary-900: 43 61 148;
 
-        --on-surface: 14 23 42;
-        --on-primary: 244 246 255;
+        --on-surface: 35 24 29;
+        --on-primary: 255 255 255;
+
+        --hero-gradient-from: 255 246 234;
+        --hero-gradient-to: 240 235 255;
+        --hero-glow-primary: 255 225 214;
+        --hero-glow-secondary: 216 222 255;
+        --overlay-backdrop: 22 18 27;
 }
 
 @layer theme {
-        [data-theme='songbook-meadow'] {
-                --color-surface-50: 240 253 244;
-                --color-surface-100: 220 252 231;
-                --color-surface-200: 187 247 208;
-                --color-surface-300: 134 239 172;
-                --color-surface-400: 74 222 128;
-                --color-surface-500: 34 197 94;
-                --color-surface-600: 22 163 74;
-                --color-surface-700: 21 128 61;
-                --color-surface-800: 22 101 52;
-                --color-surface-900: 20 83 45;
+        [data-theme='songbook-oasis'] {
+                --color-surface-50: 241 250 251;
+                --color-surface-100: 226 243 240;
+                --color-surface-200: 202 232 224;
+                --color-surface-300: 171 218 204;
+                --color-surface-400: 137 198 182;
+                --color-surface-500: 102 173 160;
+                --color-surface-600: 75 141 132;
+                --color-surface-700: 55 112 105;
+                --color-surface-800: 39 86 82;
+                --color-surface-900: 25 60 58;
 
-                --color-primary-50: 236 253 245;
-                --color-primary-100: 209 250 229;
-                --color-primary-200: 167 243 208;
-                --color-primary-300: 110 231 183;
-                --color-primary-400: 52 211 153;
-                --color-primary-500: 16 185 129;
-                --color-primary-600: 5 150 105;
-                --color-primary-700: 4 120 87;
-                --color-primary-800: 6 95 70;
-                --color-primary-900: 6 78 59;
+                --color-primary-50: 236 254 255;
+                --color-primary-100: 207 250 254;
+                --color-primary-200: 165 243 252;
+                --color-primary-300: 103 232 249;
+                --color-primary-400: 45 212 191;
+                --color-primary-500: 20 184 166;
+                --color-primary-600: 13 148 136;
+                --color-primary-700: 15 118 110;
+                --color-primary-800: 17 94 89;
+                --color-primary-900: 19 78 74;
 
-                --color-secondary-50: 240 249 255;
-                --color-secondary-100: 224 242 254;
-                --color-secondary-200: 186 230 253;
-                --color-secondary-300: 125 211 252;
-                --color-secondary-400: 56 189 248;
-                --color-secondary-500: 14 165 233;
-                --color-secondary-600: 2 132 199;
-                --color-secondary-700: 3 105 161;
-                --color-secondary-800: 7 89 133;
-                --color-secondary-900: 12 74 110;
+                --color-secondary-50: 233 244 255;
+                --color-secondary-100: 209 233 255;
+                --color-secondary-200: 178 215 254;
+                --color-secondary-300: 148 197 252;
+                --color-secondary-400: 103 172 248;
+                --color-secondary-500: 59 143 246;
+                --color-secondary-600: 37 118 226;
+                --color-secondary-700: 30 95 189;
+                --color-secondary-800: 27 76 151;
+                --color-secondary-900: 24 63 122;
 
-                --on-surface: 18 55 35;
-                --on-primary: 244 246 255;
+                --on-surface: 21 46 44;
+                --on-primary: 248 254 255;
+
+                --hero-gradient-from: 220 248 255;
+                --hero-gradient-to: 228 255 244;
+                --hero-glow-primary: 185 247 232;
+                --hero-glow-secondary: 193 225 255;
+                --overlay-backdrop: 9 30 36;
         }
 
-        [data-theme='songbook-aurora'] {
-                --color-surface-50: 248 250 252;
-                --color-surface-100: 241 245 249;
-                --color-surface-200: 226 232 240;
-                --color-surface-300: 203 213 225;
-                --color-surface-400: 148 163 184;
-                --color-surface-500: 100 116 139;
-                --color-surface-600: 71 85 105;
-                --color-surface-700: 51 65 85;
-                --color-surface-800: 30 41 59;
-                --color-surface-900: 15 23 42;
+        [data-theme='songbook-twilight'] {
+                --color-surface-50: 33 25 60;
+                --color-surface-100: 38 29 70;
+                --color-surface-200: 45 34 84;
+                --color-surface-300: 57 43 104;
+                --color-surface-400: 74 55 129;
+                --color-surface-500: 94 69 153;
+                --color-surface-600: 117 88 176;
+                --color-surface-700: 141 111 196;
+                --color-surface-800: 165 137 214;
+                --color-surface-900: 192 167 231;
 
-                --color-primary-50: 238 242 255;
-                --color-primary-100: 224 231 255;
-                --color-primary-200: 199 210 254;
-                --color-primary-300: 165 180 252;
-                --color-primary-400: 129 140 248;
-                --color-primary-500: 99 102 241;
-                --color-primary-600: 79 70 229;
-                --color-primary-700: 67 56 202;
-                --color-primary-800: 55 48 163;
-                --color-primary-900: 49 46 129;
+                --color-primary-50: 254 244 244;
+                --color-primary-100: 252 225 224;
+                --color-primary-200: 249 196 196;
+                --color-primary-300: 246 164 169;
+                --color-primary-400: 242 127 146;
+                --color-primary-500: 239 95 120;
+                --color-primary-600: 225 74 112;
+                --color-primary-700: 199 57 107;
+                --color-primary-800: 170 47 99;
+                --color-primary-900: 134 40 87;
 
-                --color-secondary-50: 236 254 255;
-                --color-secondary-100: 207 250 254;
-                --color-secondary-200: 165 243 252;
-                --color-secondary-300: 103 232 249;
-                --color-secondary-400: 34 211 238;
-                --color-secondary-500: 14 165 233;
-                --color-secondary-600: 8 145 178;
-                --color-secondary-700: 14 116 144;
-                --color-secondary-800: 21 94 117;
-                --color-secondary-900: 22 78 99;
+                --color-secondary-50: 243 240 255;
+                --color-secondary-100: 233 227 255;
+                --color-secondary-200: 214 202 255;
+                --color-secondary-300: 191 174 255;
+                --color-secondary-400: 166 142 255;
+                --color-secondary-500: 142 112 255;
+                --color-secondary-600: 118 89 240;
+                --color-secondary-700: 98 72 208;
+                --color-secondary-800: 83 60 173;
+                --color-secondary-900: 70 52 140;
 
-                --on-surface: 15 23 42;
-                --on-primary: 244 246 255;
+                --on-surface: 235 233 248;
+                --on-primary: 18 11 28;
+
+                --hero-gradient-from: 42 31 82;
+                --hero-gradient-to: 65 45 101;
+                --hero-glow-primary: 90 60 140;
+                --hero-glow-secondary: 247 192 177;
+                --overlay-backdrop: 4 3 11;
         }
 
-        [data-theme='songbook-dusk'] {
-                --color-surface-50: 59 48 94;
-                --color-surface-100: 51 42 87;
-                --color-surface-200: 44 36 79;
-                --color-surface-300: 37 31 70;
-                --color-surface-400: 31 26 62;
-                --color-surface-500: 26 22 53;
-                --color-surface-600: 21 18 45;
-                --color-surface-700: 17 15 37;
-                --color-surface-800: 13 11 29;
-                --color-surface-900: 10 8 23;
+        [data-theme='songbook-nocturne'] {
+                --color-surface-50: 12 20 34;
+                --color-surface-100: 15 27 44;
+                --color-surface-200: 18 36 58;
+                --color-surface-300: 22 48 74;
+                --color-surface-400: 27 63 94;
+                --color-surface-500: 34 82 118;
+                --color-surface-600: 43 103 143;
+                --color-surface-700: 57 128 169;
+                --color-surface-800: 78 156 194;
+                --color-surface-900: 105 188 217;
 
-                --color-primary-50: 245 243 255;
-                --color-primary-100: 237 233 254;
-                --color-primary-200: 221 214 254;
-                --color-primary-300: 196 181 253;
-                --color-primary-400: 167 139 250;
-                --color-primary-500: 139 92 246;
-                --color-primary-600: 124 58 237;
-                --color-primary-700: 109 40 217;
-                --color-primary-800: 91 33 182;
-                --color-primary-900: 76 29 149;
+                --color-primary-50: 224 255 255;
+                --color-primary-100: 187 247 248;
+                --color-primary-200: 136 232 235;
+                --color-primary-300: 94 211 222;
+                --color-primary-400: 64 188 207;
+                --color-primary-500: 45 162 189;
+                --color-primary-600: 35 133 165;
+                --color-primary-700: 30 108 137;
+                --color-primary-800: 28 86 110;
+                --color-primary-900: 26 69 87;
 
-                --color-secondary-50: 255 251 235;
-                --color-secondary-100: 254 243 199;
-                --color-secondary-200: 253 230 138;
-                --color-secondary-300: 252 211 77;
-                --color-secondary-400: 251 191 36;
-                --color-secondary-500: 245 158 11;
-                --color-secondary-600: 217 119 6;
-                --color-secondary-700: 180 83 9;
-                --color-secondary-800: 146 64 14;
-                --color-secondary-900: 120 53 15;
+                --color-secondary-50: 236 248 255;
+                --color-secondary-100: 210 236 255;
+                --color-secondary-200: 176 220 255;
+                --color-secondary-300: 139 201 252;
+                --color-secondary-400: 103 181 244;
+                --color-secondary-500: 76 158 226;
+                --color-secondary-600: 60 130 198;
+                --color-secondary-700: 52 105 165;
+                --color-secondary-800: 45 83 132;
+                --color-secondary-900: 40 68 107;
 
-                --on-surface: 229 231 235;
-                --on-primary: 248 250 255;
-        }
+                --on-surface: 220 231 240;
+                --on-primary: 6 17 23;
 
-        [data-theme='songbook-midnight'] {
-                --color-surface-50: 40 60 99;
-                --color-surface-100: 32 50 84;
-                --color-surface-200: 26 42 71;
-                --color-surface-300: 21 35 60;
-                --color-surface-400: 17 29 51;
-                --color-surface-500: 14 24 43;
-                --color-surface-600: 11 20 37;
-                --color-surface-700: 9 16 30;
-                --color-surface-800: 7 12 24;
-                --color-surface-900: 5 9 18;
-
-                --color-primary-50: 240 249 255;
-                --color-primary-100: 224 242 254;
-                --color-primary-200: 186 230 253;
-                --color-primary-300: 125 211 252;
-                --color-primary-400: 56 189 248;
-                --color-primary-500: 14 165 233;
-                --color-primary-600: 2 132 199;
-                --color-primary-700: 3 105 161;
-                --color-primary-800: 7 89 133;
-                --color-primary-900: 12 74 110;
-
-                --color-secondary-50: 245 243 255;
-                --color-secondary-100: 237 233 254;
-                --color-secondary-200: 221 214 254;
-                --color-secondary-300: 196 181 253;
-                --color-secondary-400: 167 139 250;
-                --color-secondary-500: 139 92 246;
-                --color-secondary-600: 124 58 237;
-                --color-secondary-700: 109 40 217;
-                --color-secondary-800: 91 33 182;
-                --color-secondary-900: 76 29 149;
-
-                --on-surface: 226 232 240;
-                --on-primary: 15 23 42;
+                --hero-gradient-from: 11 22 38;
+                --hero-gradient-to: 16 42 56;
+                --hero-glow-primary: 31 87 110;
+                --hero-glow-secondary: 52 141 155;
+                --overlay-backdrop: 0 8 15;
         }
 }
 
 @layer base {
-	:root {
-		color-scheme: light;
-	}
-
-	:root[data-theme='songbook-dawn'],
-	:root[data-theme='songbook-meadow'],
-	:root[data-theme='songbook-aurora'] {
-		color-scheme: light;
-	}
-
-	:root[data-theme='songbook-dusk'],
-	:root[data-theme='songbook-midnight'] {
-		color-scheme: dark;
-	}
+        :root {
+                color-scheme: light;
+        }
 
         body {
-                font-family:
-                        Inter,
-                        'SF Pro Display',
-                        -apple-system,
-                        BlinkMacSystemFont,
-                        'Segoe UI',
-                        sans-serif;
+                font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+                background: radial-gradient(120% 120% at 10% 0%, rgb(var(--hero-gradient-from) / 0.55), transparent 60%),
+                        radial-gradient(120% 120% at 90% 10%, rgb(var(--hero-gradient-to) / 0.5), transparent 65%),
+                        linear-gradient(180deg, rgb(var(--color-surface-50)) 0%, rgb(var(--color-surface-100)) 100%);
                 color: rgb(var(--on-surface));
-                @apply min-h-screen bg-surface-50 antialiased transition-colors duration-500;
+                min-height: 100vh;
         }
 
-	body.is-lenis {
-		overflow: hidden;
-	}
-
-	.lenis.lenis-smooth {
-		scroll-behavior: auto;
-	}
-
-	.lenis.lenis-smooth [data-lenis-prevent] {
-		overscroll-behavior: contain;
-	}
-
-	::selection {
-		background: rgb(var(--color-primary-400) / 0.2);
-		color: rgb(var(--on-primary));
-	}
-
-	::-webkit-scrollbar {
-		width: 12px;
-	}
-
-        ::-webkit-scrollbar-thumb {
-                background: linear-gradient(
-                        135deg,
-                        rgb(var(--color-primary-500) / 0.45),
-                        rgb(var(--color-secondary-400) / 0.35)
-                );
-                border-radius: 9999px;
-        }
-
-        ::-webkit-scrollbar-track {
-                background: rgb(var(--color-surface-900) / 0.08);
-        }
-
-	@media (prefers-reduced-motion: reduce) {
-		html:focus-within {
-			scroll-behavior: auto;
-		}
-
-		*,
-		*::before,
-		*::after {
-			animation-duration: 0.01ms !important;
-			animation-iteration-count: 1 !important;
-			transition-duration: 0.01ms !important;
-			scroll-behavior: auto !important;
-		}
-	}
-}
-
-@layer utilities {
-        .backdrop-glass {
-                @apply bg-surface-100/60 backdrop-blur-xl;
-        }
-
-        .gradient-border {
-                position: relative;
-        }
-
-        .gradient-border::before {
-                content: '';
-                position: absolute;
-                inset: -1px;
-                border-radius: inherit;
-                background: linear-gradient(
-                        130deg,
-                        rgb(var(--color-primary-400) / 0.8),
-                        rgb(var(--color-secondary-400) / 0.7)
-                );
-                mask:
-                        linear-gradient(#fff, #fff) padding-box,
-                        linear-gradient(#fff, #fff);
-                mask-composite: exclude;
-                pointer-events: none;
-        }
-
-        .text-on-surface {
-                color: rgb(var(--on-surface));
-        }
-
-        .text-on-surface-soft {
-                color: rgb(var(--on-surface) / 0.75);
-        }
-
-        .text-on-surface-muted {
-                color: rgb(var(--on-surface) / 0.6);
-        }
-
-        .text-on-surface-subtle {
-                color: rgb(var(--on-surface) / 0.45);
+        ::selection {
+                background: rgb(var(--color-primary-200));
+                color: rgb(var(--on-primary));
         }
 }

--- a/src/lib/components/layout/AppHeader.svelte
+++ b/src/lib/components/layout/AppHeader.svelte
@@ -1,32 +1,32 @@
 <script lang="ts">
-	import { browser } from '$app/environment';
-	import { t } from 'svelte-i18n';
-	import { language } from '$lib/stores/preferences';
-	import { isSyncing, lastSynced } from '$lib/stores/songStore';
-	import { derived } from 'svelte/store';
+        import { browser } from '$app/environment';
+        import { t } from 'svelte-i18n';
+        import { language } from '$lib/stores/preferences';
+        import { isSyncing, lastSynced } from '$lib/stores/songStore';
+        import { derived } from 'svelte/store';
         import { Languages, Search } from 'lucide-svelte';
         import type { SongLanguage } from '$lib/types/song';
         import ThemeSelector from '$lib/components/preferences/ThemeSelector.svelte';
         import { openSearchOverlay } from '$lib/stores/ui';
 
-	type LanguageOption = {
-		code: SongLanguage;
-		label: string;
-		shortLabel: string;
-	};
+        type LanguageOption = {
+                code: SongLanguage;
+                label: string;
+                shortLabel: string;
+        };
 
-	const syncStatus = derived(isSyncing, ($isSyncing) =>
-		$isSyncing ? $t('app.syncing') : $t('app.brand_available_offline')
-	);
+        const syncStatus = derived(isSyncing, ($isSyncing) =>
+                $isSyncing ? $t('app.syncing') : $t('app.brand_available_offline')
+        );
 
-	const languageOptions: LanguageOption[] = [
-		{ code: 'PL', label: 'Polski', shortLabel: 'PL' },
-		{ code: 'EN', label: 'English', shortLabel: 'EN' }
-	];
+        const languageOptions: LanguageOption[] = [
+                { code: 'PL', label: 'Polski', shortLabel: 'PL' },
+                { code: 'EN', label: 'English', shortLabel: 'EN' }
+        ];
 
-	function setLanguage(code: SongLanguage) {
-		language.set(code);
-	}
+        function setLanguage(code: SongLanguage) {
+                language.set(code);
+        }
 
         function focusSearch() {
                 if (!browser) return;
@@ -43,79 +43,91 @@
         }
 </script>
 
-<section class="pt-6 sm:pt-10 lg:pt-12">
-	<div
-		class="rounded-2xl border border-surface-200/70 bg-surface-50/80 p-5 shadow-lg shadow-primary-500/5 backdrop-blur-xl sm:p-7"
-	>
-		<div class="flex flex-col gap-6">
-			<div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-				<div class="space-y-2">
-					<p class="text-[11px] font-semibold uppercase tracking-[0.22em] text-primary-500">
-						{$t('app.brand_global')}
-					</p>
-                                        <h1 class="text-balance text-2xl font-semibold text-on-surface sm:text-3xl lg:text-4xl">
-                                                {$t('app.title')}
-                                        </h1>
-					<!-- <p class="max-w-2xl text-sm leading-relaxed text-surface-600">
-            {$t('app.tagline')}
-          </p> -->
-				</div>
-				<div
-					class="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end sm:gap-4"
-				>
-					<ThemeSelector />
-                                        <div
-                                                class="flex items-center gap-3 rounded-full border border-surface-200/70 bg-surface-100/70 px-3 py-1.5 text-xs font-semibold text-on-surface-soft shadow-sm"
-                                        >
-                                                <Languages class="h-4 w-4 text-primary-500" />
-                                                <span class="hidden text-[11px] uppercase tracking-[0.18em] text-on-surface-subtle sm:inline">
-                                                        {$t('app.language_label')}
-                                                </span>
-						<div class="grid grid-cols-2 gap-1 rounded-full bg-surface-50/80 p-1 shadow-inner">
-							{#each languageOptions as option}
-								<button
-									class={`rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] transition ${
-										$language === option.code
-											? 'bg-primary-500 text-white shadow'
-                                                                                        : 'text-on-surface-subtle hover:text-primary-500'
-                                                                        }`}
-									type="button"
-									aria-pressed={$language === option.code}
-									on:click={() => setLanguage(option.code)}
-								>
-									<span class="hidden sm:inline">{option.label}</span>
-									<span class="sm:hidden">{option.shortLabel}</span>
-								</button>
-							{/each}
-						</div>
-					</div>
-				</div>
-			</div>
-			<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-				<button
-					class="inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-primary-500 to-secondary-500 px-4 py-2 text-sm font-semibold text-white shadow-md transition hover:from-primary-500/90 hover:to-secondary-500/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
-					on:click={focusSearch}
-					type="button"
-				>
-					<Search class="h-4 w-4" />
-					{$t('app.search_placeholder')}
-				</button>
-                                <div class="flex flex-col gap-2 text-xs text-on-surface-soft sm:flex-row sm:items-center">
-                                        <p
-                                                class="flex items-center gap-2 rounded-full border border-surface-200/70 bg-surface-100/70 px-3 py-1.5 uppercase tracking-[0.18em]"
-                                        >
-                                                <span class="text-on-surface">{$syncStatus}</span>
-                                        </p>
-                                        <p
-                                                class="flex items-center gap-2 rounded-full border border-surface-200/70 bg-surface-100/70 px-3 py-1.5 uppercase tracking-[0.18em]"
-                                        >
-                                                <span class="text-on-surface-subtle">{$t('app.last_synced')}</span>
-                                                <span class="text-on-surface"
-                                                        >{$lastSynced ? new Date($lastSynced).toLocaleString() : '—'}</span
-                                                >
-                                        </p>
+<section class="pt-8 sm:pt-12 lg:pt-16">
+        <div
+                class="relative overflow-hidden rounded-[36px] border border-white/30 bg-surface-50/70 p-5 shadow-[0_30px_80px_rgba(15,23,42,0.12)] backdrop-blur-2xl sm:p-7"
+        >
+                <div class="pointer-events-none absolute inset-0 -z-10">
+                        <div
+                                class="absolute inset-0 bg-[linear-gradient(135deg,rgb(var(--hero-gradient-from))_0%,rgb(var(--hero-gradient-to))_60%,rgba(255,255,255,0.85)_100%)]"
+                        ></div>
+                        <div
+                                class="absolute -top-32 right-6 h-64 w-64 rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-primary)/0.45),rgba(255,255,255,0))] blur-3xl"
+                        ></div>
+                        <div
+                                class="absolute bottom-[-28%] left-[-12%] h-72 w-72 rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-secondary)/0.55),rgba(255,255,255,0))] blur-3xl"
+                        ></div>
+                </div>
+
+                <div class="relative flex flex-col gap-8">
+                        <div class="flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between">
+                                <div class="space-y-5 text-center lg:max-w-2xl lg:text-left">
+                                        <div class="inline-flex items-center gap-2 self-center rounded-full bg-white/50 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-primary-600 shadow-sm shadow-primary-500/20 lg:self-start">
+                                                {$t('app.brand_global')}
+                                        </div>
+                                        <div class="space-y-3">
+                                                <h1 class="text-balance text-3xl font-semibold text-on-surface sm:text-4xl lg:text-5xl">
+                                                        {$t('app.title')}
+                                                </h1>
+                                                <p class="text-base leading-relaxed text-on-surface-soft sm:text-lg">
+                                                        {$t('app.tagline')}
+                                                </p>
+                                        </div>
                                 </div>
-			</div>
-		</div>
-	</div>
+                                <div class="flex w-full flex-col gap-4 lg:max-w-sm">
+                                        <ThemeSelector />
+                                        <div class="rounded-[26px] border border-white/40 bg-white/40 p-4 shadow-lg shadow-primary-500/10 backdrop-blur">
+                                                <div class="flex items-center justify-between gap-3 text-xs font-semibold uppercase tracking-[0.22em] text-on-surface-subtle">
+                                                        <span class="inline-flex items-center gap-2 text-on-surface">
+                                                                <Languages class="h-4 w-4 text-primary-500" />
+                                                                {$t('app.language_label')}
+                                                        </span>
+                                                        <span class="text-[11px] text-on-surface-muted">{$t('app.view_song')}</span>
+                                                </div>
+                                                <div class="mt-3 grid grid-cols-2 gap-2">
+                                                        {#each languageOptions as option}
+                                                                <button
+                                                                        class={`rounded-2xl px-3 py-2 text-center text-[11px] font-semibold uppercase tracking-[0.2em] transition ${
+                                                                                $language === option.code
+                                                                                        ? 'bg-gradient-to-r from-primary-500 to-secondary-500 text-white shadow-lg shadow-primary-500/40'
+                                                                                        : 'bg-white/60 text-on-surface hover:bg-white/80 hover:text-primary-600'
+                                                                        }`}
+                                                                        type="button"
+                                                                        aria-pressed={$language === option.code}
+                                                                        on:click={() => setLanguage(option.code)}
+                                                                >
+                                                                        <span class="hidden sm:inline">{option.label}</span>
+                                                                        <span class="sm:hidden">{option.shortLabel}</span>
+                                                                </button>
+                                                        {/each}
+                                                </div>
+                                        </div>
+                                </div>
+                        </div>
+
+                        <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                                <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+                                        <button
+                                                class="inline-flex items-center justify-center gap-2 rounded-full bg-[radial-gradient(circle_at_top_left,_rgb(var(--color-primary-400))_0%,_rgb(var(--color-primary-600))_60%,_rgb(var(--color-secondary-500))_100%)] px-5 py-2.5 text-sm font-semibold text-white shadow-[0_18px_30px_rgba(221,91,180,0.35)] transition hover:scale-[1.01] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+                                                on:click={focusSearch}
+                                                type="button"
+                                        >
+                                                <Search class="h-4 w-4" />
+                                                {$t('app.search_placeholder')}
+                                        </button>
+                                </div>
+                                <div class="flex flex-col gap-2 text-xs text-on-surface-soft sm:flex-row sm:items-center sm:gap-3">
+                                        <div class="inline-flex items-center gap-3 rounded-full border border-white/50 bg-white/60 px-4 py-2 font-semibold uppercase tracking-[0.2em] text-on-surface">
+                                                {$syncStatus}
+                                        </div>
+                                        <div class="inline-flex items-center gap-3 rounded-full border border-white/50 bg-white/60 px-4 py-2 font-semibold uppercase tracking-[0.2em] text-on-surface">
+                                                <span class="text-on-surface-muted">{$t('app.last_synced')}</span>
+                                                <span class="text-on-surface">
+                                                        {$lastSynced ? new Date($lastSynced).toLocaleString() : '—'}
+                                                </span>
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+        </div>
 </section>

--- a/src/lib/components/preferences/ThemeSelector.svelte
+++ b/src/lib/components/preferences/ThemeSelector.svelte
@@ -1,175 +1,118 @@
 <script lang="ts">
-        import { onDestroy, onMount } from 'svelte';
-        import { tick } from 'svelte';
         import { t } from 'svelte-i18n';
-        import { Check, ChevronDown, Palette } from 'lucide-svelte';
+        import { Check, Palette } from 'lucide-svelte';
         import { themeName } from '$lib/stores/preferences';
-        import { defaultTheme, themeOptions, type ThemeOption } from '$lib/config/themes';
+        import { defaultTheme, themeOptions } from '$lib/config/themes';
 
-        let isOpen = false;
-        let triggerRef: HTMLButtonElement | null = null;
-        let menuRef: HTMLDivElement | null = null;
+        let optionRefs: HTMLButtonElement[] = [];
 
         $: activeTheme = themeOptions.find((option) => option.id === $themeName) ?? defaultTheme;
 
         function selectTheme(themeId: string) {
                 themeName.set(themeId);
-                closeMenu();
         }
 
-        function toggleMenu() {
-                if (isOpen) {
-                        closeMenu();
+        function focusOption(index: number) {
+                const target = optionRefs[index];
+                if (target) {
+                        target.focus();
+                }
+        }
+
+        function handleOptionKeydown(event: KeyboardEvent, index: number, themeId: string) {
+                const lastIndex = themeOptions.length - 1;
+                if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+                        event.preventDefault();
+                        const nextIndex = index === lastIndex ? 0 : index + 1;
+                        selectTheme(themeOptions[nextIndex].id);
+                        focusOption(nextIndex);
                         return;
                 }
-                openMenu();
-        }
-
-        async function openMenu() {
-                isOpen = true;
-                await tick();
-                focusActiveOption();
-        }
-
-        function closeMenu() {
-                isOpen = false;
-        }
-
-        function focusActiveOption() {
-                if (!menuRef) return;
-                const activeOption = menuRef.querySelector<HTMLButtonElement>("[data-active='true']");
-                activeOption?.focus();
-        }
-
-        function handleDocumentClick(event: MouseEvent) {
-                if (!isOpen) return;
-                const target = event.target as Node;
-                if (triggerRef?.contains(target) || menuRef?.contains(target)) return;
-                closeMenu();
-        }
-
-        function handleDocumentKeydown(event: KeyboardEvent) {
-                if (event.key === 'Escape' && isOpen) {
+                if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
                         event.preventDefault();
-                        closeMenu();
-                        triggerRef?.focus();
+                        const prevIndex = index === 0 ? lastIndex : index - 1;
+                        selectTheme(themeOptions[prevIndex].id);
+                        focusOption(prevIndex);
+                        return;
+                }
+                if (event.key === 'Home') {
+                        event.preventDefault();
+                        selectTheme(themeOptions[0].id);
+                        focusOption(0);
+                        return;
+                }
+                if (event.key === 'End') {
+                        event.preventDefault();
+                        selectTheme(themeOptions[lastIndex].id);
+                        focusOption(lastIndex);
+                        return;
+                }
+                if (event.key === ' ' || event.key === 'Enter') {
+                        event.preventDefault();
+                        selectTheme(themeId);
                 }
         }
-
-        function handleOptionKeydown(event: KeyboardEvent, option: ThemeOption) {
-                if (event.key === 'Enter' || event.key === ' ') {
-                        event.preventDefault();
-                        selectTheme(option.id);
-                }
-        }
-
-        onMount(() => {
-                document.addEventListener('click', handleDocumentClick);
-                document.addEventListener('keydown', handleDocumentKeydown);
-        });
-
-        onDestroy(() => {
-                document.removeEventListener('click', handleDocumentClick);
-                document.removeEventListener('keydown', handleDocumentKeydown);
-        });
 </script>
 
-<div class="space-y-3 rounded-2xl border border-surface-200/70 bg-surface-50/80 px-4 py-3 text-xs font-semibold text-on-surface-soft shadow-sm backdrop-blur">
+<div class="space-y-4 rounded-[28px] border border-surface-200/70 bg-surface-50/75 p-4 shadow-xl shadow-primary-500/10 backdrop-blur-xl sm:p-5">
         <div class="flex items-center gap-3">
-                <span class="flex h-9 w-9 items-center justify-center rounded-full border border-primary-200/60 bg-primary-50/70 text-primary-500 shadow-sm">
+                <span class="flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-primary-500/90 to-secondary-500/90 text-on-primary shadow-lg shadow-primary-500/30">
                         <Palette class="h-4 w-4" aria-hidden="true" />
                 </span>
                 <div>
-                        <p class="text-[11px] uppercase tracking-[0.18em] text-on-surface-subtle">
+                        <p class="text-[11px] font-semibold uppercase tracking-[0.2em] text-on-surface-subtle">
                                 {$t('app.theme_label')}
                         </p>
                         <p class="text-sm font-semibold text-on-surface">
                                 {$t(`app.themes.${activeTheme.labelKey}`)}
+                                <span class="ml-2 text-xs font-medium text-on-surface-muted">
+                                        {$t(`app.theme_scheme.${activeTheme.scheme}`)}
+                                </span>
                         </p>
                 </div>
         </div>
-        <div class="relative">
-                <button
-                        class="flex w-full items-center justify-between gap-3 rounded-2xl border border-surface-200/70 bg-surface-50/80 px-4 py-3 text-left text-sm font-semibold text-on-surface-soft shadow-sm backdrop-blur transition hover:border-primary-300 hover:text-primary-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-400"
-                        type="button"
-                        aria-haspopup="listbox"
-                        aria-expanded={isOpen}
-                        on:click={toggleMenu}
-                        bind:this={triggerRef}
-                >
-                        <span class="flex flex-1 items-center gap-3">
-                                <span class="flex h-9 w-16 overflow-hidden rounded-full border border-surface-200/70 bg-surface-100/70 shadow-inner">
-                                        {#each activeTheme.preview as color}
-                                                <span class="flex-1" style={`background:${color}`}></span>
-                                        {/each}
-                                </span>
-                                <span class="flex flex-1 flex-col text-left">
-                                        <span class="text-sm font-semibold text-on-surface">
-                                                {$t(`app.themes.${activeTheme.labelKey}`)}
-                                        </span>
-                                        <span class="text-[11px] uppercase tracking-[0.18em] text-on-surface-subtle">
-                                                {$t(`app.theme_scheme.${activeTheme.scheme}`)}
-                                        </span>
-                                </span>
-                        </span>
-                        <ChevronDown
-                                class={`h-4 w-4 transition-transform ${isOpen ? 'rotate-180 text-primary-500' : 'text-on-surface-muted'}`}
-                                aria-hidden="true"
-                        />
-                </button>
-
-                {#if isOpen}
-                        <div
-                                class="absolute left-0 right-0 z-20 mt-2 origin-top rounded-2xl border border-surface-200/80 bg-surface-50/95 p-2 shadow-xl backdrop-blur"
-                                role="listbox"
-                                aria-label={$t('app.theme_label')}
-                                bind:this={menuRef}
+        <div class="grid gap-3 sm:grid-cols-2" role="radiogroup" aria-label={$t('app.theme_label')}>
+                {#each themeOptions as option, index}
+                        <button
+                                class={`group relative flex flex-col gap-3 overflow-hidden rounded-2xl border p-3 text-left transition-all duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-400 ${
+                                        option.id === $themeName
+                                                ? 'border-primary-300/80 bg-white/70 text-on-surface shadow-[0_20px_45px_rgba(15,23,42,0.12)]'
+                                                : 'border-surface-200/60 bg-surface-100/40 text-on-surface-muted hover:border-primary-200/60 hover:bg-surface-100/70 hover:text-primary-600'
+                                }`}
+                                type="button"
+                                role="radio"
+                                aria-checked={option.id === $themeName}
+                                tabindex={option.id === $themeName ? 0 : -1}
+                                on:click={() => selectTheme(option.id)}
+                                on:keydown={(event) => handleOptionKeydown(event, index, option.id)}
+                                bind:this={optionRefs[index]}
                         >
-                                {#each themeOptions as option}
-                                        <button
-                                                class={`group flex w-full items-center gap-3 rounded-2xl px-3.5 py-2.5 text-left text-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-400 ${
-                                                        option.id === $themeName
-                                                                ? 'bg-primary-50/70 text-on-surface shadow-sm'
-                                                                : 'text-on-surface-soft hover:bg-surface-100/80 hover:text-primary-500'
-                                                }`}
-                                                type="button"
-                                                role="option"
-                                                aria-selected={option.id === $themeName}
-                                                data-active={option.id === $themeName}
-                                                on:click={() => selectTheme(option.id)}
-                                                on:keydown={(event) => handleOptionKeydown(event, option)}
-                                        >
-                                                <span
-                                                        class={`flex h-9 w-16 overflow-hidden rounded-full border shadow-inner ${
-                                                                option.id === $themeName
-                                                                        ? 'border-primary-300'
-                                                                        : 'border-surface-200/70'
-                                                        }`}
-                                                >
-                                                        {#each option.preview as color}
-                                                                <span class="flex-1" style={`background:${color}`}></span>
-                                                        {/each}
+                                <span class="relative flex h-16 w-full items-center justify-center overflow-hidden rounded-xl">
+                                        <span
+                                                class="absolute inset-0 bg-[linear-gradient(135deg,var(--from),var(--via),var(--to))] opacity-90"
+                                                style={`--from:${option.preview[0]};--via:${option.preview[1]};--to:${option.preview[2]};`}
+                                                aria-hidden="true"
+                                        ></span>
+                                        <span class="absolute inset-0 bg-black/10" aria-hidden="true"></span>
+                                        <span class="relative text-[11px] font-semibold uppercase tracking-[0.2em] text-white/80">
+                                                {$t(`app.theme_scheme.${option.scheme}`)}
+                                        </span>
+                                </span>
+                                <span class="flex items-center justify-between gap-3">
+                                        <span class="text-sm font-semibold">
+                                                {$t(`app.themes.${option.labelKey}`)}
+                                        </span>
+                                        {#if option.id === $themeName}
+                                                <span class="flex h-6 w-6 items-center justify-center rounded-full bg-primary-500 text-on-primary shadow-lg">
+                                                        <Check class="h-3.5 w-3.5" aria-hidden="true" />
                                                 </span>
-                                                <span class="flex flex-1 flex-col text-left">
-                                                        <span class="text-sm font-semibold text-on-surface">
-                                                                {$t(`app.themes.${option.labelKey}`)}
-                                                        </span>
-                                                        <span class="text-[11px] uppercase tracking-[0.18em] text-on-surface-subtle">
-                                                                {$t(`app.theme_scheme.${option.scheme}`)}
-                                                        </span>
+                                        {:else}
+                                                <span class="flex h-6 w-6 items-center justify-center rounded-full border border-surface-200/60 text-on-surface-muted transition group-hover:border-primary-300/60 group-hover:text-primary-500">
+                                                        <Check class="h-3.5 w-3.5" aria-hidden="true" />
                                                 </span>
-                                                {#if option.id === $themeName}
-                                                        <span class="text-primary-500">
-                                                                <Check class="h-4 w-4" aria-hidden="true" />
-                                                        </span>
-                                                {:else}
-                                                        <span class="text-on-surface-muted opacity-0 transition group-hover:opacity-100">
-                                                                <Check class="h-4 w-4" aria-hidden="true" />
-                                                        </span>
-                                                {/if}
-                                        </button>
-                                {/each}
-                        </div>
-                {/if}
+                                        {/if}
+                                </span>
+                        </button>
+                {/each}
         </div>
 </div>

--- a/src/lib/components/search/SearchOverlay.svelte
+++ b/src/lib/components/search/SearchOverlay.svelte
@@ -85,28 +85,29 @@
 
 {#if $isSearchOverlayOpen}
         <div
-                class="fixed inset-0 z-50 flex items-start justify-center bg-surface-900/50 px-4 py-16 backdrop-blur"
+                class="fixed inset-0 z-50 flex items-start justify-center px-4 py-16 backdrop-blur-2xl"
+                style="background-color: rgba(var(--overlay-backdrop), 0.58);"
                 role="presentation"
                 on:click={handleBackdropClick}
                 on:keydown={handleKeydown}
         >
                 <div
-                        class="w-full max-w-xl rounded-3xl border border-surface-200/70 bg-surface-50/95 p-5 shadow-2xl"
+                        class="w-full max-w-2xl rounded-[32px] border border-white/20 bg-white/85 p-6 shadow-[0_40px_120px_rgba(15,23,42,0.32)]"
                         role="dialog"
                         aria-modal="true"
                         tabindex="-1"
                         bind:this={panelRef}
                 >
-                        <div class="flex items-start justify-between gap-3">
+                        <div class="flex items-start justify-between gap-4">
                                 <div class="flex-1">
                                         <label
-                                                class="text-[11px] font-semibold uppercase tracking-[0.2em] text-on-surface-subtle"
+                                                class="text-[11px] font-semibold uppercase tracking-[0.22em] text-on-surface-muted"
                                                 for="search-overlay-input"
                                         >
                                                 {$t('app.search_placeholder')}
                                         </label>
                                         <div
-                                                class="mt-2 flex items-center gap-2.5 rounded-xl border border-surface-200/60 bg-surface-100/70 px-3.5 py-2.5 shadow-inner"
+                                                class="mt-3 flex items-center gap-3 rounded-2xl border border-white/30 bg-white/60 px-4 py-3 shadow-inner shadow-primary-500/10"
                                         >
                                                 <Search class="h-4 w-4 text-primary-500" aria-hidden="true" />
                                                 <input
@@ -121,7 +122,7 @@
                                         </div>
                                 </div>
                                 <button
-                                        class="inline-flex shrink-0 items-center justify-center rounded-full border border-surface-200/70 bg-surface-100/70 p-2 text-on-surface-soft transition hover:border-primary-300 hover:text-primary-400"
+                                        class="inline-flex shrink-0 items-center justify-center rounded-full border border-white/40 bg-white/70 p-2 text-on-surface-soft transition hover:border-primary-200 hover:text-primary-500"
                                         type="button"
                                         on:click={handleClose}
                                 >
@@ -131,20 +132,20 @@
                         </div>
 
                         {#if results.length}
-                                <div class="mt-5 space-y-2">
+                                <div class="mt-6 space-y-3">
                                         {#each results as song (song.id + song.language)}
                                                 <button
-                                                        class="flex w-full items-center justify-between gap-3 rounded-2xl border border-surface-200/70 bg-surface-50/80 px-4 py-3 text-left text-sm font-medium text-on-surface transition hover:border-primary-400 hover:text-primary-500"
+                                                        class="flex w-full items-center justify-between gap-4 rounded-2xl border border-white/40 bg-white/70 px-5 py-3.5 text-left text-sm font-semibold text-on-surface transition hover:border-primary-300 hover:text-primary-600 hover:shadow-[0_18px_40px_rgba(15,23,42,0.12)]"
                                                         type="button"
                                                         on:click={() => handleSelect(song)}
                                                 >
                                                         <div>
-                                                                <p class="font-semibold">{song.title}</p>
+                                                                <p class="font-semibold text-on-surface">{song.title}</p>
                                                                 <p class="text-xs text-on-surface-muted">
                                                                         {$t('app.page_label')} {song.page} · {song.source}
                                                                 </p>
                                                         </div>
-                                                        <span class="text-[11px] font-semibold uppercase tracking-[0.2em] text-primary-400/80">
+                                                        <span class="text-[11px] font-semibold uppercase tracking-[0.22em] text-primary-400/90">
                                                                 {$t('app.view_song')}
                                                         </span>
                                                 </button>

--- a/src/lib/components/song/SongCard.svelte
+++ b/src/lib/components/song/SongCard.svelte
@@ -92,10 +92,10 @@
 
 <div use:inView on:enterViewport={handleEnter}>
 	{#if visible}
-		<article
-			class="rounded-2xl border border-surface-200/60 bg-surface-50/80 p-4 shadow-lg shadow-primary-500/5 transition hover:-translate-y-1 hover:shadow-xl sm:p-5"
-			use:listTransition={index}
-		>
+                <article
+                        class="rounded-[28px] border border-white/40 bg-white/75 p-4 shadow-[0_24px_60px_rgba(15,23,42,0.08)] backdrop-blur-2xl transition hover:-translate-y-1 hover:shadow-[0_30px_80px_rgba(15,23,42,0.14)] sm:p-6"
+                        use:listTransition={index}
+                >
 			<div class="flex flex-col gap-5">
 				<div class="flex flex-col gap-3.5 lg:flex-row lg:items-start lg:justify-between">
 					<div class="space-y-3">
@@ -107,55 +107,55 @@
                                                                 </p>
                                                         {/if}
                                                 </div>
-                                                <div class="flex flex-wrap items-center gap-2 text-xs text-on-surface-subtle">
-                                                        <span
-                                                                class="inline-flex items-center gap-2 rounded-full border border-surface-200/60 bg-surface-100/70 px-3 py-1 font-medium text-on-surface"
-                                                        >
-                                                                {$t('app.page_label')}
-                                                                {song.page}
-                                                        </span>
-                                                        <span
-                                                                class="inline-flex items-center gap-2 rounded-full border border-surface-200/60 bg-surface-100/70 px-3 py-1 text-on-surface-soft"
-                                                        >
-                                                                {$t('app.source_label')}
-                                                                {song.source}
-                                                        </span>
-                                                        <span
-                                                                class="inline-flex items-center gap-2 rounded-full border border-surface-200/60 bg-surface-100/70 px-3 py-1 text-on-surface-soft"
-                                                        >
-                                                                {$t('app.external_index')}
-                                                                {song.externalIndex}
-                                                        </span>
-                                                </div>
+                                        <div class="flex flex-wrap items-center gap-2 text-xs text-on-surface-subtle">
+                                                <span
+                                                        class="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/70 px-3 py-1 font-medium text-on-surface"
+                                                >
+                                                        {$t('app.page_label')}
+                                                        {song.page}
+                                                </span>
+                                                <span
+                                                        class="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/60 px-3 py-1 text-on-surface-soft"
+                                                >
+                                                        {$t('app.source_label')}
+                                                        {song.source}
+                                                </span>
+                                                <span
+                                                        class="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/60 px-3 py-1 text-on-surface-soft"
+                                                >
+                                                        {$t('app.external_index')}
+                                                        {song.externalIndex}
+                                                </span>
+                                        </div>
 					</div>
 					<div class="flex flex-wrap justify-end gap-2 text-sm">
-						<button
-							class={`inline-flex items-center gap-2 rounded-full border border-surface-200/60 bg-surface-100/70 px-3.5 py-1.5 text-sm font-medium transition hover:border-primary-400 hover:text-primary-500 ${
+                                                <button
+                                                        class={`inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-sm font-medium transition ${
                                                                 isFavourite
-                                                                        ? 'bg-primary-500/10 text-primary-600 shadow-inner shadow-primary-500/20'
-                                                                        : 'text-on-surface'
+                                                                        ? 'bg-gradient-to-r from-primary-500/90 to-secondary-500/90 text-white shadow-lg shadow-primary-500/40'
+                                                                        : 'border border-white/60 bg-white/70 text-on-surface hover:border-primary-200/70 hover:text-primary-600'
                                                         }`}
-							on:click={() => dispatch('toggleFavourite', `${song.id}-${song.language}`)}
-							type="button"
-						>
+                                                        on:click={() => dispatch('toggleFavourite', `${song.id}-${song.language}`)}
+                                                        type="button"
+                                                >
 							<Heart class={`h-4 w-4 ${isFavourite ? 'fill-current' : ''}`} />
 							{isFavourite ? $t('app.remove_favourite') : $t('app.add_favourite')}
 						</button>
-						<button
-							class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-primary-500 to-secondary-500 px-3.5 py-1.5 text-sm font-semibold text-white shadow-md transition hover:from-primary-500/90 hover:to-secondary-500/90"
-							on:click={() => dispatch('open', song)}
-							type="button"
-						>
+                                                <button
+                                                        class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-primary-500 to-secondary-500 px-3.5 py-1.5 text-sm font-semibold text-white shadow-[0_20px_35px_rgba(221,91,180,0.35)] transition hover:scale-[1.01] hover:from-primary-500/90 hover:to-secondary-500/90"
+                                                        on:click={() => dispatch('open', song)}
+                                                        type="button"
+                                                >
 							<ExternalLink class="h-4 w-4" />
 							{$t('app.view_song')}
 						</button>
 						{#if remainingItems.length}
-							<button
-								class="inline-flex items-center gap-2 rounded-full border border-surface-200/60 bg-surface-100/70 px-3.5 py-1.5 text-sm font-medium text-surface-600 transition hover:border-primary-400 hover:text-primary-500"
-								on:click={() => (expanded = !expanded)}
-								type="button"
-								aria-expanded={expanded}
-							>
+                                                        <button
+                                                                class="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/70 px-3.5 py-1.5 text-sm font-medium text-on-surface transition hover:border-primary-200/70 hover:text-primary-600"
+                                                                on:click={() => (expanded = !expanded)}
+                                                                type="button"
+                                                                aria-expanded={expanded}
+                                                        >
 								{#if expanded}
 									<EyeOff class="h-4 w-4" />
 									{$t('app.hide_preview')}
@@ -165,11 +165,11 @@
 								{/if}
 							</button>
 						{/if}
-						<button
-							class="inline-flex items-center gap-2 rounded-full border border-surface-200/60 bg-surface-100/70 px-3.5 py-1.5 text-sm font-medium text-surface-600 transition hover:border-primary-400 hover:text-primary-500"
-							on:click={copyShareLink}
-							type="button"
-						>
+                                                <button
+                                                        class="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/70 px-3.5 py-1.5 text-sm font-medium text-on-surface transition hover:border-primary-200/70 hover:text-primary-600"
+                                                        on:click={copyShareLink}
+                                                        type="button"
+                                                >
 							<Link2 class="h-4 w-4" />
 							{copyState === 'copied' ? $t('app.copied_link') : $t('app.copy_link')}
 						</button>

--- a/src/lib/config/themes.ts
+++ b/src/lib/config/themes.ts
@@ -1,47 +1,45 @@
 export type ThemeOption = {
-	id: string;
-	labelKey: string;
-	preview: string[];
-	scheme: 'light' | 'dark';
-	metaColor: string;
+        id: string;
+        labelKey: string;
+        preview: string[];
+        scheme: 'light' | 'dark';
+        metaColor: string;
+        hero: [string, string];
 };
 
 export const themeOptions: ThemeOption[] = [
-	{
-		id: 'songbook-dawn',
-		labelKey: 'dawn',
-		preview: ['#fff7ed', '#fed7aa', '#fb923c'],
-		scheme: 'light',
-		metaColor: '#fde68a'
-	},
-	{
-		id: 'songbook-meadow',
-		labelKey: 'meadow',
-		preview: ['#ecfdf3', '#bbf7d0', '#34d399'],
-		scheme: 'light',
-		metaColor: '#86efac'
-	},
-	{
-		id: 'songbook-aurora',
-		labelKey: 'aurora',
-		preview: ['#eef2ff', '#c7d2fe', '#6366f1'],
-		scheme: 'light',
-		metaColor: '#a5b4fc'
-	},
-	{
-		id: 'songbook-dusk',
-		labelKey: 'dusk',
-		preview: ['#ede9fe', '#c4b5fd', '#7c3aed'],
-		scheme: 'dark',
-		metaColor: '#5b21b6'
-	},
-	{
-		id: 'songbook-midnight',
-		labelKey: 'midnight',
-		preview: ['#0f172a', '#1e293b', '#38bdf8'],
-		scheme: 'dark',
-		metaColor: '#0f172a'
-	}
+        {
+                id: 'songbook-lumen',
+                labelKey: 'lumen',
+                preview: ['#ffe9d6', '#ffd3eb', '#d6c7ff'],
+                scheme: 'light',
+                metaColor: '#fde9ff',
+                hero: ['#fff6ea', '#f1ecff']
+        },
+        {
+                id: 'songbook-oasis',
+                labelKey: 'oasis',
+                preview: ['#ddf7ff', '#c7f5de', '#7dd3fc'],
+                scheme: 'light',
+                metaColor: '#c8f5ff',
+                hero: ['#ecfbff', '#e8fff4']
+        },
+        {
+                id: 'songbook-twilight',
+                labelKey: 'twilight',
+                preview: ['#433d8b', '#7257b5', '#ee8468'],
+                scheme: 'dark',
+                metaColor: '#1c163f',
+                hero: ['#2a1f52', '#412d65']
+        },
+        {
+                id: 'songbook-nocturne',
+                labelKey: 'nocturne',
+                preview: ['#0f1c2e', '#12354a', '#4bc5c5'],
+                scheme: 'dark',
+                metaColor: '#0b1626',
+                hero: ['#0b1626', '#102b38']
+        }
 ];
 
 export const defaultTheme = themeOptions[0];

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -6,11 +6,10 @@
 		"language_label": "Language",
                 "theme_label": "Theme",
                 "themes": {
-                        "dawn": "Warm Light",
-                        "meadow": "Forest",
-                        "aurora": "Indigo",
-                        "dusk": "Twilight",
-                        "midnight": "Midnight"
+                        "lumen": "Lumen",
+                        "oasis": "Oasis",
+                        "twilight": "Twilight",
+                        "nocturne": "Nocturne"
                 },
                 "theme_scheme": {
                         "light": "Light",

--- a/src/lib/locales/pl.json
+++ b/src/lib/locales/pl.json
@@ -6,11 +6,10 @@
 		"language_label": "Język",
                 "theme_label": "Motyw",
                 "themes": {
-                        "dawn": "Ciepłe światło",
-                        "meadow": "Leśny",
-                        "aurora": "Indygo",
-                        "dusk": "Zmierzch",
-                        "midnight": "Północ"
+                        "lumen": "Lumen",
+                        "oasis": "Oaza",
+                        "twilight": "Zmierzch",
+                        "nocturne": "Nokturn"
                 },
                 "theme_scheme": {
                         "light": "Jasny",

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -61,20 +61,23 @@
 </script>
 
 <div class="relative min-h-screen overflow-hidden text-on-surface">
-	<div class="pointer-events-none absolute inset-0 -z-10">
-		<div
-			class="absolute inset-0 bg-gradient-to-b from-surface-50 via-surface-100/80 to-surface-50"
-		></div>
-		<div
-			class="absolute left-1/2 top-[-25%] h-[28rem] w-[28rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgb(var(--color-secondary-200)/0.45),_rgba(255,255,255,0))] blur-3xl"
-		></div>
-		<div
-			class="absolute bottom-[-18%] right-[-10%] h-[26rem] w-[26rem] rounded-full bg-[radial-gradient(circle_at_center,_rgb(var(--color-primary-200)/0.35),_rgba(255,255,255,0))] blur-3xl"
-		></div>
-	</div>
-	<div
-		class="relative mx-auto flex min-h-screen w-full max-w-5xl flex-col px-3 pb-12 sm:px-5 lg:max-w-6xl lg:px-8"
-	>
+        <div class="pointer-events-none absolute inset-0 -z-10">
+                <div
+                        class="absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.9)_0%,rgba(255,255,255,0.7)_45%,rgba(255,255,255,0.85)_100%)]"
+                ></div>
+                <div
+                        class="absolute left-[10%] top-[-12%] h-[28rem] w-[28rem] rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-secondary)/0.55),rgba(255,255,255,0))] blur-3xl"
+                ></div>
+                <div
+                        class="absolute right-[-10%] top-[5%] h-[34rem] w-[34rem] rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-primary)/0.5),rgba(255,255,255,0))] blur-[150px]"
+                ></div>
+                <div
+                        class="absolute bottom-[-24%] left-1/2 h-[30rem] w-[30rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,rgba(255,255,255,0.9),rgba(255,255,255,0))] blur-[160px]"
+                ></div>
+        </div>
+        <div
+                class="relative mx-auto flex min-h-screen w-full max-w-5xl flex-col px-4 pb-12 sm:px-6 lg:max-w-6xl lg:px-8"
+        >
                 <AppHeader />
                 <main class="flex-1 py-6 sm:py-8 lg:py-10">
                         <slot />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -95,10 +95,10 @@
 </script>
 
 <section class="space-y-8 pb-16">
-	<div
-		class="space-y-5 rounded-2xl border border-surface-200/60 bg-surface-50/80 p-5 shadow-lg shadow-primary-500/5 backdrop-blur-xl sm:p-6"
-		use:fadeSlide
-	>
+        <div
+                class="space-y-5 rounded-[30px] border border-white/40 bg-white/75 p-5 shadow-[0_25px_70px_rgba(15,23,42,0.08)] backdrop-blur-2xl sm:p-6"
+                use:fadeSlide
+        >
 		<div class="space-y-2">
 			<!-- <label
         class="text-[11px] font-semibold uppercase tracking-[0.2em] text-surface-500"
@@ -106,10 +106,10 @@
       >
         {$t('app.search_placeholder')}
       </label> -->
-			<div
-				class="flex items-center gap-2.5 rounded-xl border border-surface-200/60 bg-surface-100/70 px-3.5 py-2.5 shadow-inner"
-			>
-				<Search class="h-4 w-4 text-primary-500" />
+                        <div
+                                class="flex items-center gap-3 rounded-2xl border border-white/30 bg-white/60 px-4 py-3 shadow-inner shadow-primary-500/5"
+                        >
+                                <Search class="h-4 w-4 text-primary-500" />
                                 <input
                                         id="song-search"
                                         class="w-full bg-transparent text-sm text-on-surface outline-none placeholder:text-on-surface-muted sm:text-base"
@@ -118,16 +118,16 @@
                                         bind:value={query}
 					bind:this={searchRef}
 				/>
-				{#if query}
-					<button
-						class="text-[11px] font-semibold uppercase tracking-[0.2em] text-primary-500 transition hover:text-primary-400"
-						on:click={() => (query = '')}
-						type="button"
-					>
-						{$t('app.clear_query')}
-					</button>
-				{/if}
-			</div>
+                                {#if query}
+                                        <button
+                                                class="rounded-full bg-white/70 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-primary-600 shadow-sm transition hover:bg-white"
+                                                on:click={() => (query = '')}
+                                                type="button"
+                                        >
+                                                {$t('app.clear_query')}
+                                        </button>
+                                {/if}
+                        </div>
 			<!-- <p class="text-xs text-surface-500">{$t('app.search_hint')}</p> -->
 		</div>
 
@@ -146,53 +146,53 @@
 		</div>
 
 		{#if filterBadges.length}
-			<div class="flex flex-wrap gap-2">
-				{#each filterBadges as badge}
-					<span
-						class="inline-flex items-center gap-2 rounded-full border border-primary-200/60 bg-primary-50 px-3 py-1 text-xs font-semibold text-primary-600"
-					>
-						{badge}
-					</span>
-				{/each}
-			</div>
-		{/if}
-	</div>
+                        <div class="flex flex-wrap gap-2">
+                                {#each filterBadges as badge}
+                                        <span
+                                                class="inline-flex items-center gap-2 rounded-full border border-primary-200/60 bg-primary-50/80 px-3 py-1 text-xs font-semibold text-primary-600 shadow-sm"
+                                        >
+                                                {badge}
+                                        </span>
+                                {/each}
+                        </div>
+                {/if}
+        </div>
 
-	<div
-		class="space-y-5 rounded-2xl border border-surface-200/60 bg-surface-50/80 p-5 shadow-lg shadow-primary-500/5 backdrop-blur-xl sm:p-6"
-		use:fadeSlide={{ axis: 'y', from: 30, delay: 0.05 }}
-	>
-		<div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-			<div class="flex flex-wrap gap-2">
-				<button
-					class={`inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-sm font-semibold transition ${
-						menuView === 'index'
-							? 'bg-primary-500 text-white shadow-sm'
-							: 'border border-surface-200/60 bg-surface-100/70 text-surface-600 hover:border-primary-400 hover:text-primary-500'
-					}`}
-					on:click={() => (menuView = 'index')}
-					type="button"
-				>
+        <div
+                class="space-y-5 rounded-[30px] border border-white/40 bg-white/75 p-5 shadow-[0_25px_70px_rgba(15,23,42,0.08)] backdrop-blur-2xl sm:p-6"
+                use:fadeSlide={{ axis: 'y', from: 30, delay: 0.05 }}
+        >
+                <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                        <div class="flex flex-wrap gap-2">
+                                <button
+                                        class={`inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-sm font-semibold transition ${
+                                                menuView === 'index'
+                                                        ? 'bg-gradient-to-r from-primary-500 to-secondary-500 text-white shadow-lg shadow-primary-500/30'
+                                                        : 'border border-white/50 bg-white/60 text-on-surface hover:border-primary-200/70 hover:text-primary-600'
+                                        }`}
+                                        on:click={() => (menuView = 'index')}
+                                        type="button"
+                                >
 					<LayoutList class="h-4 w-4" />
 					{$t('app.toggle_index')}
 				</button>
-				<button
-					class={`inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-sm font-semibold transition ${
-						menuView === 'favourites'
-							? 'bg-primary-500 text-white shadow-sm'
-							: 'border border-surface-200/60 bg-surface-100/70 text-surface-600 hover:border-primary-400 hover:text-primary-500'
-					}`}
-					on:click={() => (menuView = 'favourites')}
-					type="button"
-				>
+                                <button
+                                        class={`inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-sm font-semibold transition ${
+                                                menuView === 'favourites'
+                                                        ? 'bg-gradient-to-r from-primary-500 to-secondary-500 text-white shadow-lg shadow-primary-500/30'
+                                                        : 'border border-white/50 bg-white/60 text-on-surface hover:border-primary-200/70 hover:text-primary-600'
+                                        }`}
+                                        on:click={() => (menuView = 'favourites')}
+                                        type="button"
+                                >
 					<Heart class="h-4 w-4" />
 					{$t('app.toggle_favourites')}
 				</button>
-				<button
-					class="inline-flex items-center gap-2 rounded-full border border-surface-200/60 bg-surface-100/70 px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.2em] text-surface-500 transition hover:border-primary-400 hover:text-primary-500"
-					on:click={handleClearFilters}
-					type="button"
-				>
+                                <button
+                                        class="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/60 px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-on-surface-muted transition hover:border-primary-200/70 hover:text-primary-600"
+                                        on:click={handleClearFilters}
+                                        type="button"
+                                >
 					{$t('app.reset_filters')}
 				</button>
 			</div>

--- a/src/routes/song/[id]/+page.svelte
+++ b/src/routes/song/[id]/+page.svelte
@@ -1,38 +1,71 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import { goto } from '$app/navigation';
-	import { page } from '$app/stores';
-	import { t } from 'svelte-i18n';
-	import { get } from 'svelte/store';
-	import { getSongByKey } from '$lib/stores/songStore';
-	import { favourites, toggleFavourite, language, viewMode } from '$lib/stores/preferences';
-	import type { Song, SongLanguage } from '$lib/types/song';
+        import { goto } from '$app/navigation';
+        import { page } from '$app/stores';
+        import { t } from 'svelte-i18n';
+        import { getSongByKey } from '$lib/stores/songStore';
+        import { favourites, toggleFavourite, language, viewMode } from '$lib/stores/preferences';
+        import type { Song, SongLanguage } from '$lib/types/song';
 
-	let song: Song | null = null;
-	let loading = true;
-	let activeViewMode: 'basic' | 'chords' = 'basic';
-	let lastUpdatedLabel: string | null = null;
+        let song: Song | null = null;
+        let loading = true;
+        let activeViewMode: 'basic' | 'chords' = 'basic';
+        let lastUpdatedLabel: string | null = null;
+        let loadSequence = 0;
+        let initialised = false;
+        let lastRouteId: string | null = null;
+        let lastRequestedKey: string | null = null;
 
-	onMount(async () => {
-		const $page = get(page);
-		const langParam = $page.url.searchParams.get('lang')?.toUpperCase() as SongLanguage | undefined;
-		const activeLang = langParam ?? get(language);
-		if (langParam) {
-			language.set(langParam);
-		}
-		song = await getSongByKey(`${$page.params.id}-${activeLang}`);
-		loading = false;
-	});
+        async function fetchSong(id: string, targetLanguage: SongLanguage) {
+                const sequence = ++loadSequence;
+                loading = true;
+                try {
+                        const nextSong = await getSongByKey(`${id}-${targetLanguage}`);
+                        if (sequence !== loadSequence) return;
+                        song = nextSong;
+                } finally {
+                        if (sequence === loadSequence) {
+                                loading = false;
+                        }
+                }
+        }
 
-	$: favouriteKey = song ? `${song.id}-${song.language}` : '';
-	$: activeViewMode = $viewMode;
-	$: lastUpdatedLabel = song?.lastUpdatedAt
-		? new Date(song.lastUpdatedAt).toLocaleDateString(undefined, {
+        $: favouriteKey = song ? `${song.id}-${song.language}` : '';
+        $: activeViewMode = $viewMode;
+        $: lastUpdatedLabel = song?.lastUpdatedAt
+                ? new Date(song.lastUpdatedAt).toLocaleDateString(undefined, {
 				day: 'numeric',
 				month: 'short',
 				year: 'numeric'
 			})
-		: null;
+                : null;
+
+        $: {
+                const id = $page.params.id;
+                if (!id) {
+                        song = null;
+                        loading = false;
+                } else {
+                        if (lastRouteId !== id) {
+                                initialised = false;
+                                lastRouteId = id;
+                                lastRequestedKey = null;
+                        }
+
+                        const langParam = $page.url.searchParams.get('lang')?.toUpperCase() as SongLanguage | undefined;
+                        const shouldRespectParam = Boolean(langParam) && !initialised;
+                        if (shouldRespectParam && langParam && $language !== langParam) {
+                                language.set(langParam);
+                        }
+
+                        const targetLanguage = shouldRespectParam && langParam ? langParam : $language;
+                        const requestKey = `${id}-${targetLanguage}`;
+                        if (requestKey !== lastRequestedKey) {
+                                lastRequestedKey = requestKey;
+                                void fetchSong(id, targetLanguage);
+                        }
+                        initialised = true;
+                }
+        }
 
 	function itemText(item: Song['items'][number]) {
 		return typeof item.text === 'string' ? item.text : '';
@@ -69,46 +102,46 @@
 {#if loading}
 	<div class="py-20 text-center text-sm text-[rgb(var(--text-secondary))]">{$t('app.syncing')}</div>
 {:else if song}
-	<article
-		class="relative mx-auto max-w-4xl space-y-7 overflow-hidden rounded-2xl border border-primary-500/20 bg-surface-50/90 p-5 shadow-2xl backdrop-blur-xl sm:space-y-8 sm:rounded-[2.5rem] sm:p-8 lg:p-10"
-	>
-		<div class="pointer-events-none absolute inset-0 -z-10">
-			<div
-				class="absolute -top-24 left-10 h-48 w-48 rounded-full bg-primary-500/15 blur-[120px]"
-			></div>
-			<div
-				class="absolute bottom-0 right-0 h-56 w-56 rounded-full bg-secondary-400/20 blur-[140px]"
-			></div>
-		</div>
+        <article
+                class="relative mx-auto max-w-4xl space-y-7 overflow-hidden rounded-[3rem] border border-white/30 bg-white/80 p-6 shadow-[0_40px_110px_rgba(15,23,42,0.18)] backdrop-blur-2xl sm:space-y-8 sm:p-10 lg:p-12"
+        >
+                <div class="pointer-events-none absolute inset-0 -z-10">
+                        <div
+                                class="absolute -top-32 left-8 h-64 w-64 rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-primary)/0.4),rgba(255,255,255,0))] blur-[140px]"
+                        ></div>
+                        <div
+                                class="absolute bottom-[-12%] right-[-8%] h-72 w-72 rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-secondary)/0.45),rgba(255,255,255,0))] blur-[160px]"
+                        ></div>
+                </div>
 
 		<header class="relative space-y-5 text-center lg:text-left">
 			<div class="flex flex-1 flex-wrap items-center justify-between gap-3">
-				<div class="flex flex-wrap items-center gap-2.5">
-					<button
-						class="inline-flex items-center gap-2 rounded-full border border-primary-500/20 bg-surface-100/70 px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.2em] text-primary-500 transition hover:-translate-y-0.5 hover:border-primary-500 hover:text-primary-500"
-						type="button"
-						on:click={goBack}
-					>
-						{$t('app.back_action')}
-					</button>
-					<button
-						class="inline-flex items-center gap-2 rounded-full border border-primary-500/20 bg-surface-100/70 px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.2em] text-primary-500 transition hover:-translate-y-0.5 hover:border-primary-500 hover:text-primary-500"
-						type="button"
-						on:click={() => goto('/')}
-					>
-						{$t('app.back_to_index')}
-					</button>
-				</div>
-				<button
-					class={`inline-flex items-center justify-center gap-2 rounded-full px-4 py-1.5 text-sm font-semibold transition ${
-						$favourites.includes(favouriteKey)
-							? 'bg-gradient-to-r from-primary-500 to-secondary-400 text-white shadow-lg'
-							: 'border border-primary-500/25 bg-surface-100/70 text-surface-600 hover:border-primary-500 hover:text-primary-500'
-					}`}
-					type="button"
-					aria-pressed={$favourites.includes(favouriteKey)}
-					on:click={() => toggleFavourite(favouriteKey)}
-				>
+                                <div class="flex flex-wrap items-center gap-2.5">
+                                        <button
+                                                class="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/70 px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-on-surface transition hover:-translate-y-0.5 hover:border-primary-200/70 hover:text-primary-600"
+                                                type="button"
+                                                on:click={goBack}
+                                        >
+                                                {$t('app.back_action')}
+                                        </button>
+                                        <button
+                                                class="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/70 px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-on-surface transition hover:-translate-y-0.5 hover:border-primary-200/70 hover:text-primary-600"
+                                                type="button"
+                                                on:click={() => goto('/')}
+                                        >
+                                                {$t('app.back_to_index')}
+                                        </button>
+                                </div>
+                                <button
+                                        class={`inline-flex items-center justify-center gap-2 rounded-full px-4 py-1.5 text-sm font-semibold transition ${
+                                                $favourites.includes(favouriteKey)
+                                                        ? 'bg-gradient-to-r from-primary-500 to-secondary-500 text-white shadow-lg shadow-primary-500/30'
+                                                        : 'border border-white/60 bg-white/70 text-on-surface hover:border-primary-200/70 hover:text-primary-600'
+                                        }`}
+                                        type="button"
+                                        aria-pressed={$favourites.includes(favouriteKey)}
+                                        on:click={() => toggleFavourite(favouriteKey)}
+                                >
 					{$favourites.includes(favouriteKey)
 						? $t('app.remove_favourite')
 						: $t('app.add_favourite')}
@@ -117,31 +150,31 @@
 
 			<div class="space-y-3">
 				<div class="space-y-2">
-                                        <h1 class="text-balance text-2xl font-semibold text-on-surface sm:text-3xl lg:text-4xl">
+                                        <h1 class="text-balance text-3xl font-semibold text-on-surface sm:text-4xl lg:text-5xl">
                                                 {song.title}
                                         </h1>
-					{#if lastUpdatedLabel}
-						<p class="text-[11px] uppercase tracking-[0.2em] text-primary-400/80">
-							{$t('app.updated_label')}: {lastUpdatedLabel}
-						</p>
-					{/if}
-				</div>
+                                        {#if lastUpdatedLabel}
+                                                <p class="text-[11px] uppercase tracking-[0.22em] text-primary-400/90">
+                                                        {$t('app.updated_label')}: {lastUpdatedLabel}
+                                                </p>
+                                        {/if}
+                                </div>
                                 <div class="flex flex-wrap justify-center gap-2 text-xs text-on-surface-subtle lg:justify-start">
-					<span
-						class="rounded-full bg-primary-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-primary-500"
-					>
-						{$t('app.page_label')}
-						{song.page}
-					</span>
-                                        <span class="rounded-full bg-surface-100/70 px-3 py-1 text-[11px] text-on-surface-soft">
+                                        <span
+                                                class="rounded-full bg-primary-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-primary-500"
+                                        >
+                                                {$t('app.page_label')}
+                                                {song.page}
+                                        </span>
+                                        <span class="rounded-full border border-white/60 bg-white/60 px-3 py-1 text-[11px] text-on-surface-soft">
                                                 {$t('app.source_label')}
                                                 {song.source}
                                         </span>
-                                        <span class="rounded-full bg-surface-100/70 px-3 py-1 text-[11px] text-on-surface-soft">
+                                        <span class="rounded-full border border-white/60 bg-white/60 px-3 py-1 text-[11px] text-on-surface-soft">
                                                 {$t('app.external_index')}
                                                 {song.externalIndex}
                                         </span>
-				</div>
+                                </div>
 			</div>
 
 			<div
@@ -150,11 +183,11 @@
 				aria-label={$t('app.view_song')}
 			>
 				<button
-					class={`inline-flex items-center justify-center gap-2 rounded-full px-4 py-1.5 text-sm font-semibold transition ${
-						activeViewMode === 'basic'
-							? 'bg-gradient-to-r from-primary-500 to-secondary-400 text-white shadow-lg'
-							: 'border border-primary-500/20 bg-surface-100/70 text-surface-600'
-					}`}
+                                        class={`inline-flex items-center justify-center gap-2 rounded-full px-4 py-1.5 text-sm font-semibold transition ${
+                                                activeViewMode === 'basic'
+                                                        ? 'bg-gradient-to-r from-primary-500 to-secondary-500 text-white shadow-lg shadow-primary-500/30'
+                                                        : 'border border-white/60 bg-white/70 text-on-surface'
+                                        }`}
 					type="button"
 					role="tab"
 					aria-selected={activeViewMode === 'basic'}
@@ -165,11 +198,11 @@
 					{$t('app.view.basic')}
 				</button>
 				<button
-					class={`inline-flex items-center justify-center gap-2 rounded-full px-4 py-1.5 text-sm font-semibold transition ${
-						activeViewMode === 'chords'
-							? 'bg-gradient-to-r from-primary-500 to-secondary-400 text-white shadow-lg'
-							: 'border border-primary-500/20 bg-surface-100/70 text-surface-600'
-					}`}
+                                        class={`inline-flex items-center justify-center gap-2 rounded-full px-4 py-1.5 text-sm font-semibold transition ${
+                                                activeViewMode === 'chords'
+                                                        ? 'bg-gradient-to-r from-primary-500 to-secondary-500 text-white shadow-lg shadow-primary-500/30'
+                                                        : 'border border-white/60 bg-white/70 text-on-surface'
+                                        }`}
 					type="button"
 					role="tab"
 					aria-selected={activeViewMode === 'chords'}
@@ -182,11 +215,11 @@
 			</div>
 		</header>
 
-		<section
-			class={`relative space-y-3 rounded-xl border border-primary-500/10 bg-surface-50/80 p-4 text-left text-sm leading-relaxed shadow-inner sm:rounded-2xl sm:p-6 sm:text-base ${
-				activeViewMode === 'chords' ? 'lg:grid lg:grid-cols-[160px,1fr] lg:gap-6 lg:space-y-0' : ''
-			}`}
-		>
+                <section
+                        class={`relative space-y-3 rounded-[26px] border border-white/40 bg-white/65 p-5 text-left text-sm leading-relaxed shadow-inner shadow-primary-500/10 sm:p-7 sm:text-base ${
+                                activeViewMode === 'chords' ? 'lg:grid lg:grid-cols-[160px,1fr] lg:gap-6 lg:space-y-0' : ''
+                        }`}
+                >
 			{#each song.items as item}
 				{#if itemText(item).trim().length}
 					<p


### PR DESCRIPTION
## Summary
- rebuild the theme palette with new light and dark schemes and update locale labels
- redesign the theme picker, header, layout, search overlay, and song listing cards with the new aesthetic
- fix song detail navigation so selecting a song refreshes content when navigating via the search overlay

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68db1db99da483279be0b4b394b10c9f