### PR TITLE
Revamp mobile styling and improve song navigation

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -3,47 +3,47 @@
 
 @theme {
         /* default light theme tokens */
-        --color-surface-50: 255 249 243;
-        --color-surface-100: 253 240 230;
-        --color-surface-200: 249 225 210;
-        --color-surface-300: 242 203 184;
-        --color-surface-400: 230 177 153;
-        --color-surface-500: 213 146 118;
-        --color-surface-600: 184 114 93;
-        --color-surface-700: 151 88 74;
-        --color-surface-800: 117 66 59;
-        --color-surface-900: 82 47 44;
+        --color-surface-50: 249 250 251;
+        --color-surface-100: 243 245 247;
+        --color-surface-200: 229 233 239;
+        --color-surface-300: 210 217 226;
+        --color-surface-400: 176 190 205;
+        --color-surface-500: 136 152 170;
+        --color-surface-600: 102 120 140;
+        --color-surface-700: 76 90 110;
+        --color-surface-800: 50 64 83;
+        --color-surface-900: 28 36 50;
 
-        --color-primary-50: 255 240 252;
-        --color-primary-100: 252 231 247;
-        --color-primary-200: 249 214 239;
-        --color-primary-300: 244 185 226;
-        --color-primary-400: 236 140 204;
-        --color-primary-500: 221 91 180;
-        --color-primary-600: 196 64 164;
-        --color-primary-700: 165 52 143;
-        --color-primary-800: 133 46 120;
-        --color-primary-900: 103 38 95;
+        --color-primary-50: 240 249 255;
+        --color-primary-100: 224 242 254;
+        --color-primary-200: 186 230 253;
+        --color-primary-300: 125 211 252;
+        --color-primary-400: 56 189 248;
+        --color-primary-500: 14 165 233;
+        --color-primary-600: 2 132 199;
+        --color-primary-700: 3 105 161;
+        --color-primary-800: 7 89 133;
+        --color-primary-900: 12 74 110;
 
-        --color-secondary-50: 239 244 255;
-        --color-secondary-100: 224 232 255;
-        --color-secondary-200: 202 215 255;
-        --color-secondary-300: 178 197 255;
-        --color-secondary-400: 146 173 255;
-        --color-secondary-500: 109 143 255;
-        --color-secondary-600: 82 116 245;
-        --color-secondary-700: 63 92 220;
-        --color-secondary-800: 51 74 185;
-        --color-secondary-900: 43 61 148;
+        --color-secondary-50: 253 244 255;
+        --color-secondary-100: 250 232 255;
+        --color-secondary-200: 245 208 254;
+        --color-secondary-300: 235 180 252;
+        --color-secondary-400: 216 150 250;
+        --color-secondary-500: 192 109 240;
+        --color-secondary-600: 168 85 227;
+        --color-secondary-700: 147 51 234;
+        --color-secondary-800: 126 34 206;
+        --color-secondary-900: 107 33 168;
 
-        --on-surface: 35 24 29;
+        --on-surface: 18 30 39;
         --on-primary: 255 255 255;
 
-        --hero-gradient-from: 255 246 234;
-        --hero-gradient-to: 240 235 255;
-        --hero-glow-primary: 255 225 214;
-        --hero-glow-secondary: 216 222 255;
-        --overlay-backdrop: 22 18 27;
+        --hero-gradient-from: 240 249 255;
+        --hero-gradient-to: 253 244 255;
+        --hero-glow-primary: 186 230 253;
+        --hero-glow-secondary: 235 180 252;
+        --overlay-backdrop: 9 16 26;
 }
 
 @layer base {
@@ -53,8 +53,8 @@
 
         body {
                 font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-                background: radial-gradient(120% 120% at 10% 0%, rgb(var(--hero-gradient-from) / 0.55), transparent 60%),
-                        radial-gradient(120% 120% at 90% 10%, rgb(var(--hero-gradient-to) / 0.5), transparent 65%),
+                background: radial-gradient(140% 120% at 10% 0%, rgb(var(--hero-gradient-from) / 0.65), transparent 60%),
+                        radial-gradient(110% 130% at 90% 10%, rgb(var(--hero-gradient-to) / 0.55), transparent 65%),
                         linear-gradient(180deg, rgb(var(--color-surface-50)) 0%, rgb(var(--color-surface-100)) 100%);
                 color: rgb(var(--on-surface));
                 min-height: 100vh;

--- a/src/lib/components/layout/AppHeader.svelte
+++ b/src/lib/components/layout/AppHeader.svelte
@@ -42,53 +42,49 @@
         }
 </script>
 
-<section class="pt-8 sm:pt-12 lg:pt-16">
+<section class="pt-6 sm:pt-12 lg:pt-16">
         <div
-                class="relative overflow-hidden rounded-[36px] border border-white/30 bg-surface-50/70 p-5 shadow-[0_30px_80px_rgba(15,23,42,0.12)] backdrop-blur-2xl sm:p-7"
+                class="relative overflow-hidden rounded-3xl border border-white/40 bg-white/70 p-4 shadow-[0_24px_70px_rgba(15,23,42,0.1)] backdrop-blur-2xl sm:p-6"
         >
                 <div class="pointer-events-none absolute inset-0 -z-10">
                         <div
-                                class="absolute inset-0 bg-[linear-gradient(135deg,rgb(var(--hero-gradient-from))_0%,rgb(var(--hero-gradient-to))_60%,rgba(255,255,255,0.85)_100%)]"
+                                class="absolute inset-0 bg-[linear-gradient(140deg,rgb(var(--hero-gradient-from))_0%,rgba(255,255,255,0.92)_55%,rgb(var(--hero-gradient-to))_100%)]"
                         ></div>
                         <div
-                                class="absolute -top-32 right-6 h-64 w-64 rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-primary)/0.45),rgba(255,255,255,0))] blur-3xl"
+                                class="absolute -top-24 right-6 h-56 w-56 rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-primary)/0.45),rgba(255,255,255,0))] blur-3xl"
                         ></div>
                         <div
-                                class="absolute bottom-[-28%] left-[-12%] h-72 w-72 rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-secondary)/0.55),rgba(255,255,255,0))] blur-3xl"
+                                class="absolute bottom-[-28%] left-[-12%] h-64 w-64 rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-secondary)/0.5),rgba(255,255,255,0))] blur-3xl"
                         ></div>
                 </div>
 
                 <div class="relative flex flex-col gap-8">
                         <div class="flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between">
-                                <div class="space-y-5 text-center lg:max-w-2xl lg:text-left">
-                                        <div class="inline-flex items-center gap-2 self-center rounded-full bg-white/50 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-primary-600 shadow-sm shadow-primary-500/20 lg:self-start">
+                                <div class="space-y-4 text-center lg:max-w-2xl lg:text-left">
+                                        <div class="inline-flex items-center gap-2 self-center rounded-full bg-primary-50/80 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-primary-600 shadow-sm shadow-primary-500/20 lg:self-start">
                                                 {$t('app.brand_global')}
                                         </div>
-                                        <div class="space-y-3">
+                                        <div class="space-y-2">
                                                 <h1 class="text-balance text-3xl font-semibold text-on-surface sm:text-4xl lg:text-5xl">
                                                         {$t('app.title')}
                                                 </h1>
-                                                <p class="text-base leading-relaxed text-on-surface-soft sm:text-lg">
-                                                        {$t('app.tagline')}
-                                                </p>
                                         </div>
                                 </div>
                                 <div class="flex w-full flex-col lg:max-w-sm">
-                                        <div class="rounded-[26px] border border-white/40 bg-white/70 p-4 shadow-lg shadow-primary-500/10 backdrop-blur">
+                                        <div class="rounded-2xl border border-white/50 bg-white/80 p-4 shadow-lg shadow-primary-500/10 backdrop-blur">
                                                 <div class="flex items-center justify-between gap-3 text-xs font-semibold uppercase tracking-[0.22em] text-on-surface-subtle">
                                                         <span class="inline-flex items-center gap-2 text-on-surface">
                                                                 <Languages class="h-4 w-4 text-primary-500" />
                                                                 {$t('app.language_label')}
                                                         </span>
-                                                        <span class="text-[11px] text-on-surface-muted">{$t('app.view_song')}</span>
                                                 </div>
                                                 <div class="mt-3 grid grid-cols-2 gap-2">
                                                         {#each languageOptions as option}
                                                                 <button
-                                                                        class={`rounded-2xl px-3 py-2 text-center text-[11px] font-semibold uppercase tracking-[0.2em] transition ${
+                                                                        class={`rounded-xl px-3 py-2 text-center text-[11px] font-semibold uppercase tracking-[0.2em] transition ${
                                                                                 $language === option.code
                                                                                         ? 'bg-gradient-to-r from-primary-500 to-secondary-500 text-white shadow-lg shadow-primary-500/40'
-                                                                                        : 'bg-white/60 text-on-surface hover:bg-white/80 hover:text-primary-600'
+                                                                                        : 'bg-white/70 text-on-surface hover:bg-primary-50 hover:text-primary-600'
                                                                         }`}
                                                                         type="button"
                                                                         aria-pressed={$language === option.code}
@@ -106,7 +102,7 @@
                         <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                                 <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
                                         <button
-                                                class="inline-flex items-center justify-center gap-2 rounded-full bg-[radial-gradient(circle_at_top_left,_rgb(var(--color-primary-400))_0%,_rgb(var(--color-primary-600))_60%,_rgb(var(--color-secondary-500))_100%)] px-5 py-2.5 text-sm font-semibold text-white shadow-[0_18px_30px_rgba(221,91,180,0.35)] transition hover:scale-[1.01] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+                                                class="inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-primary-500 via-primary-600 to-secondary-500 px-5 py-2.5 text-sm font-semibold text-white shadow-[0_14px_28px_rgba(14,165,233,0.32)] transition hover:scale-[1.01] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
                                                 on:click={focusSearch}
                                                 type="button"
                                         >
@@ -115,10 +111,10 @@
                                         </button>
                                 </div>
                                 <div class="flex flex-col gap-2 text-xs text-on-surface-soft sm:flex-row sm:items-center sm:gap-3">
-                                        <div class="inline-flex items-center gap-3 rounded-full border border-white/50 bg-white/60 px-4 py-2 font-semibold uppercase tracking-[0.2em] text-on-surface">
+                                        <div class="inline-flex items-center gap-3 rounded-full border border-white/40 bg-white/70 px-4 py-2 font-semibold uppercase tracking-[0.2em] text-on-surface">
                                                 {$syncStatus}
                                         </div>
-                                        <div class="inline-flex items-center gap-3 rounded-full border border-white/50 bg-white/60 px-4 py-2 font-semibold uppercase tracking-[0.2em] text-on-surface">
+                                        <div class="inline-flex items-center gap-3 rounded-full border border-white/40 bg-white/70 px-4 py-2 font-semibold uppercase tracking-[0.2em] text-on-surface">
                                                 <span class="text-on-surface-muted">{$t('app.last_synced')}</span>
                                                 <span class="text-on-surface">
                                                         {$lastSynced ? new Date($lastSynced).toLocaleString() : '—'}

--- a/src/lib/components/search/SearchOverlay.svelte
+++ b/src/lib/components/search/SearchOverlay.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
         import { browser } from '$app/environment';
-        import { afterNavigate } from '$app/navigation';
+        import { afterNavigate, goto } from '$app/navigation';
         import { tick } from 'svelte';
         import { t } from 'svelte-i18n';
         import { Search, X } from 'lucide-svelte';
         import { favourites, language } from '$lib/stores/preferences';
         import { closeSearchOverlay, isSearchOverlayOpen } from '$lib/stores/ui';
         import { filterSongs, searchableSongs } from '$lib/stores/songStore';
+        import type { Song } from '$lib/types/song';
 
         let query = '';
         let inputRef: HTMLInputElement | null = null;
@@ -35,6 +36,12 @@
                         event.preventDefault();
                         handleClose();
                 }
+        }
+
+        async function handleSongSelect(song: Song) {
+                const url = `/song/${song.id}?lang=${song.language}`;
+                handleClose();
+                await goto(url, { noScroll: false });
         }
 
         async function focusInput() {
@@ -76,14 +83,14 @@
 
 {#if $isSearchOverlayOpen}
         <div
-                class="fixed inset-0 z-50 flex items-start justify-center px-4 py-16 backdrop-blur-2xl"
+                class="fixed inset-0 z-50 flex items-start justify-center px-3 py-12 backdrop-blur-2xl sm:px-4 sm:py-16"
                 style="background-color: rgba(var(--overlay-backdrop), 0.58);"
                 role="presentation"
                 on:click={handleBackdropClick}
                 on:keydown={handleKeydown}
         >
                 <div
-                        class="w-full max-w-2xl rounded-[32px] border border-white/20 bg-white/85 p-6 shadow-[0_40px_120px_rgba(15,23,42,0.32)]"
+                        class="w-full max-w-2xl rounded-[28px] border border-white/30 bg-white/85 p-4 shadow-[0_34px_110px_rgba(15,23,42,0.24)] sm:p-6"
                         role="dialog"
                         aria-modal="true"
                         tabindex="-1"
@@ -98,7 +105,7 @@
                                                 {$t('app.search_placeholder')}
                                         </label>
                                         <div
-                                                class="mt-3 flex items-center gap-3 rounded-2xl border border-white/30 bg-white/60 px-4 py-3 shadow-inner shadow-primary-500/10"
+                                                class="mt-3 flex items-center gap-3 rounded-2xl border border-white/40 bg-white/70 px-4 py-3 shadow-inner shadow-primary-500/10"
                                         >
                                                 <Search class="h-4 w-4 text-primary-500" aria-hidden="true" />
                                                 <input
@@ -125,10 +132,10 @@
                         {#if results.length}
                                 <div class="mt-6 space-y-3">
                                         {#each results as song (song.id + song.language)}
-                                                <a
+                                                <button
                                                         class="flex w-full items-center justify-between gap-4 rounded-2xl border border-white/40 bg-white/70 px-5 py-3.5 text-left text-sm font-semibold text-on-surface transition hover:border-primary-300 hover:text-primary-600 hover:shadow-[0_18px_40px_rgba(15,23,42,0.12)]"
-                                                        href={`/song/${song.id}?lang=${song.language}`}
-                                                        on:click={handleClose}
+                                                        type="button"
+                                                        on:click={() => handleSongSelect(song)}
                                                 >
                                                         <div>
                                                                 <p class="font-semibold text-on-surface">{song.title}</p>
@@ -137,9 +144,9 @@
                                                                 </p>
                                                         </div>
                                                         <span class="text-[11px] font-semibold uppercase tracking-[0.22em] text-primary-400/90">
-                                                                {$t('app.view_song')}
+                                                                {$t('app.go_to_song')}
                                                         </span>
-                                                </a>
+                                                </button>
                                         {/each}
                                 </div>
                         {:else if hasQuery}

--- a/src/lib/components/song/SongCard.svelte
+++ b/src/lib/components/song/SongCard.svelte
@@ -93,7 +93,7 @@
 <div use:inView on:enterViewport={handleEnter}>
 	{#if visible}
                 <article
-                        class="rounded-[28px] border border-white/40 bg-white/75 p-4 shadow-[0_24px_60px_rgba(15,23,42,0.08)] backdrop-blur-2xl transition hover:-translate-y-1 hover:shadow-[0_30px_80px_rgba(15,23,42,0.14)] sm:p-6"
+                        class="rounded-3xl border border-white/40 bg-white/80 p-4 shadow-[0_24px_60px_rgba(15,23,42,0.08)] backdrop-blur-2xl transition hover:-translate-y-1 hover:shadow-[0_28px_72px_rgba(15,23,42,0.12)] sm:p-6"
                         use:listTransition={index}
                 >
 			<div class="flex flex-col gap-5">
@@ -109,19 +109,19 @@
                                                 </div>
                                         <div class="flex flex-wrap items-center gap-2 text-xs text-on-surface-subtle">
                                                 <span
-                                                        class="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/70 px-3 py-1 font-medium text-on-surface"
+                                                        class="inline-flex items-center gap-2 rounded-full border border-primary-100/70 bg-primary-50/90 px-3 py-1 font-medium text-primary-600"
                                                 >
                                                         {$t('app.page_label')}
                                                         {song.page}
                                                 </span>
                                                 <span
-                                                        class="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/60 px-3 py-1 text-on-surface-soft"
+                                                        class="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/70 px-3 py-1 text-on-surface-soft"
                                                 >
                                                         {$t('app.source_label')}
                                                         {song.source}
                                                 </span>
                                                 <span
-                                                        class="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/60 px-3 py-1 text-on-surface-soft"
+                                                        class="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/70 px-3 py-1 text-on-surface-soft"
                                                 >
                                                         {$t('app.external_index')}
                                                         {song.externalIndex}
@@ -132,8 +132,8 @@
                                                 <button
                                                         class={`inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-sm font-medium transition ${
                                                                 isFavourite
-                                                                        ? 'bg-gradient-to-r from-primary-500/90 to-secondary-500/90 text-white shadow-lg shadow-primary-500/40'
-                                                                        : 'border border-white/60 bg-white/70 text-on-surface hover:border-primary-200/70 hover:text-primary-600'
+                                                                        ? 'bg-gradient-to-r from-primary-500 to-secondary-500 text-white shadow-[0_18px_32px_rgba(14,165,233,0.28)]'
+                                                                        : 'border border-white/50 bg-white/80 text-on-surface hover:border-primary-200/70 hover:text-primary-600'
                                                         }`}
                                                         on:click={() => dispatch('toggleFavourite', `${song.id}-${song.language}`)}
                                                         type="button"
@@ -142,16 +142,16 @@
 							{isFavourite ? $t('app.remove_favourite') : $t('app.add_favourite')}
 						</button>
                                                 <button
-                                                        class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-primary-500 to-secondary-500 px-3.5 py-1.5 text-sm font-semibold text-white shadow-[0_20px_35px_rgba(221,91,180,0.35)] transition hover:scale-[1.01] hover:from-primary-500/90 hover:to-secondary-500/90"
+                                                        class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-primary-500 via-primary-600 to-secondary-500 px-3.5 py-1.5 text-sm font-semibold text-white shadow-[0_20px_36px_rgba(14,165,233,0.28)] transition hover:scale-[1.01] hover:from-primary-500/90 hover:to-secondary-500/90"
                                                         on:click={() => dispatch('open', song)}
                                                         type="button"
                                                 >
-							<ExternalLink class="h-4 w-4" />
-							{$t('app.view_song')}
+                                                        <ExternalLink class="h-4 w-4" />
+                                                        {$t('app.go_to_song')}
 						</button>
 						{#if remainingItems.length}
                                                         <button
-                                                                class="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/70 px-3.5 py-1.5 text-sm font-medium text-on-surface transition hover:border-primary-200/70 hover:text-primary-600"
+                                                                class="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/80 px-3.5 py-1.5 text-sm font-medium text-on-surface transition hover:border-primary-200/70 hover:text-primary-600"
                                                                 on:click={() => (expanded = !expanded)}
                                                                 type="button"
                                                                 aria-expanded={expanded}
@@ -166,7 +166,7 @@
 							</button>
 						{/if}
                                                 <button
-                                                        class="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/70 px-3.5 py-1.5 text-sm font-medium text-on-surface transition hover:border-primary-200/70 hover:text-primary-600"
+                                                        class="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/80 px-3.5 py-1.5 text-sm font-medium text-on-surface transition hover:border-primary-200/70 hover:text-primary-600"
                                                         on:click={copyShareLink}
                                                         type="button"
                                                 >

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -31,7 +31,7 @@
                 "page_label": "Page",
                 "source_label": "Source",
                 "external_index": "Index",
-                "view_song": "View song",
+                "view_song": "Viewing mode",
                 "brand_global": "KWCh Bible Fellowship",
                 "brand_available_offline": "Offline ready",
                 "sort": {

--- a/src/lib/locales/pl.json
+++ b/src/lib/locales/pl.json
@@ -31,7 +31,7 @@
                 "page_label": "Strona",
                 "source_label": "Źródło",
                 "external_index": "Indeks",
-                "view_song": "Zobacz pieśń",
+                "view_song": "Tryb wyświetlania",
                 "brand_global": "Wspólnota Biblijna KWCh",
                 "brand_available_offline": "Działa offline",
                 "sort": {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -63,23 +63,23 @@
 <div class="relative min-h-screen overflow-hidden text-on-surface">
         <div class="pointer-events-none absolute inset-0 -z-10">
                 <div
-                        class="absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.9)_0%,rgba(255,255,255,0.7)_45%,rgba(255,255,255,0.85)_100%)]"
+                        class="absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.92)_0%,rgba(255,255,255,0.78)_40%,rgba(255,255,255,0.88)_100%)]"
                 ></div>
                 <div
-                        class="absolute left-[10%] top-[-12%] h-[28rem] w-[28rem] rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-secondary)/0.55),rgba(255,255,255,0))] blur-3xl"
+                        class="absolute left-[8%] top-[-16%] h-[22rem] w-[22rem] rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-secondary)/0.5),rgba(255,255,255,0))] blur-[140px]"
                 ></div>
                 <div
-                        class="absolute right-[-10%] top-[5%] h-[34rem] w-[34rem] rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-primary)/0.5),rgba(255,255,255,0))] blur-[150px]"
+                        class="absolute right-[-12%] top-[0%] h-[28rem] w-[28rem] rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-primary)/0.55),rgba(255,255,255,0))] blur-[150px]"
                 ></div>
                 <div
-                        class="absolute bottom-[-24%] left-1/2 h-[30rem] w-[30rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,rgba(255,255,255,0.9),rgba(255,255,255,0))] blur-[160px]"
+                        class="absolute bottom-[-26%] left-1/2 h-[28rem] w-[28rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,rgba(255,255,255,0.92),rgba(255,255,255,0))] blur-[170px]"
                 ></div>
         </div>
         <div
-                class="relative mx-auto flex min-h-screen w-full max-w-5xl flex-col px-4 pb-12 sm:px-6 lg:max-w-6xl lg:px-8"
+                class="relative mx-auto flex min-h-screen w-full max-w-5xl flex-col px-3 pb-10 sm:px-6 lg:max-w-6xl lg:px-10"
         >
                 <AppHeader />
-                <main class="flex-1 py-6 sm:py-8 lg:py-10">
+                <main class="flex-1 py-5 sm:py-8 lg:py-10">
                         <slot />
                 </main>
                 <footer class="mt-10 border-t border-surface-200/60 py-5 text-xs text-on-surface-muted sm:text-sm">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -94,9 +94,9 @@
 	}
 </script>
 
-<section class="space-y-8 pb-16">
+<section class="space-y-6 pb-14 sm:space-y-8">
         <div
-                class="space-y-5 rounded-[30px] border border-white/40 bg-white/75 p-5 shadow-[0_25px_70px_rgba(15,23,42,0.08)] backdrop-blur-2xl sm:p-6"
+                class="space-y-5 rounded-3xl border border-white/40 bg-white/80 p-4 shadow-[0_25px_70px_rgba(15,23,42,0.08)] backdrop-blur-2xl sm:p-6"
                 use:fadeSlide
         >
 		<div class="space-y-2">
@@ -107,7 +107,7 @@
         {$t('app.search_placeholder')}
       </label> -->
                         <div
-                                class="flex items-center gap-3 rounded-2xl border border-white/30 bg-white/60 px-4 py-3 shadow-inner shadow-primary-500/5"
+                                class="flex items-center gap-3 rounded-2xl border border-white/40 bg-white/70 px-4 py-3 shadow-inner shadow-primary-500/10"
                         >
                                 <Search class="h-4 w-4 text-primary-500" />
                                 <input
@@ -120,7 +120,7 @@
 				/>
                                 {#if query}
                                         <button
-                                                class="rounded-full bg-white/70 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-primary-600 shadow-sm transition hover:bg-white"
+                                                class="rounded-full bg-white/80 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-primary-600 shadow-sm transition hover:bg-white"
                                                 on:click={() => (query = '')}
                                                 type="button"
                                         >
@@ -131,7 +131,7 @@
 			<!-- <p class="text-xs text-surface-500">{$t('app.search_hint')}</p> -->
 		</div>
 
-                <div class="flex flex-wrap items-center gap-3 text-sm text-on-surface-soft">
+                <div class="flex flex-wrap items-center gap-3 text-xs text-on-surface-soft sm:text-sm">
                         <span class="font-semibold text-on-surface">{filteredSongs.length}</span>
 			<span>/</span>
 			<span>{availableSongs.length}</span>
@@ -149,7 +149,7 @@
                         <div class="flex flex-wrap gap-2">
                                 {#each filterBadges as badge}
                                         <span
-                                                class="inline-flex items-center gap-2 rounded-full border border-primary-200/60 bg-primary-50/80 px-3 py-1 text-xs font-semibold text-primary-600 shadow-sm"
+                                                class="inline-flex items-center gap-2 rounded-full border border-primary-100/70 bg-primary-50/90 px-3 py-1 text-xs font-semibold text-primary-600 shadow-sm"
                                         >
                                                 {badge}
                                         </span>
@@ -159,7 +159,7 @@
         </div>
 
         <div
-                class="space-y-5 rounded-[30px] border border-white/40 bg-white/75 p-5 shadow-[0_25px_70px_rgba(15,23,42,0.08)] backdrop-blur-2xl sm:p-6"
+                class="space-y-5 rounded-3xl border border-white/40 bg-white/80 p-4 shadow-[0_25px_70px_rgba(15,23,42,0.08)] backdrop-blur-2xl sm:p-6"
                 use:fadeSlide={{ axis: 'y', from: 30, delay: 0.05 }}
         >
                 <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
@@ -168,7 +168,7 @@
                                         class={`inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-sm font-semibold transition ${
                                                 menuView === 'index'
                                                         ? 'bg-gradient-to-r from-primary-500 to-secondary-500 text-white shadow-lg shadow-primary-500/30'
-                                                        : 'border border-white/50 bg-white/60 text-on-surface hover:border-primary-200/70 hover:text-primary-600'
+                                                        : 'border border-white/50 bg-white/70 text-on-surface hover:border-primary-200/70 hover:text-primary-600'
                                         }`}
                                         on:click={() => (menuView = 'index')}
                                         type="button"
@@ -180,7 +180,7 @@
                                         class={`inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-sm font-semibold transition ${
                                                 menuView === 'favourites'
                                                         ? 'bg-gradient-to-r from-primary-500 to-secondary-500 text-white shadow-lg shadow-primary-500/30'
-                                                        : 'border border-white/50 bg-white/60 text-on-surface hover:border-primary-200/70 hover:text-primary-600'
+                                                        : 'border border-white/50 bg-white/70 text-on-surface hover:border-primary-200/70 hover:text-primary-600'
                                         }`}
                                         on:click={() => (menuView = 'favourites')}
                                         type="button"
@@ -189,7 +189,7 @@
 					{$t('app.toggle_favourites')}
 				</button>
                                 <button
-                                        class="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/60 px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-on-surface-muted transition hover:border-primary-200/70 hover:text-primary-600"
+                                        class="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/70 px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-on-surface-muted transition hover:border-primary-200/70 hover:text-primary-600"
                                         on:click={handleClearFilters}
                                         type="button"
                                 >

--- a/src/routes/song/[id]/+page.svelte
+++ b/src/routes/song/[id]/+page.svelte
@@ -118,14 +118,14 @@
 			<div class="flex flex-1 flex-wrap items-center justify-between gap-3">
                                 <div class="flex flex-wrap items-center gap-2.5">
                                         <button
-                                                class="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/70 px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-on-surface transition hover:-translate-y-0.5 hover:border-primary-200/70 hover:text-primary-600"
+                                                class="inline-flex items-center gap-2 rounded-full border border-white/40 bg-white/75 px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-on-surface transition hover:-translate-y-0.5 hover:border-primary-200/70 hover:text-primary-600"
                                                 type="button"
                                                 on:click={goBack}
                                         >
                                                 {$t('app.back_action')}
                                         </button>
                                         <button
-                                                class="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/70 px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-on-surface transition hover:-translate-y-0.5 hover:border-primary-200/70 hover:text-primary-600"
+                                                class="inline-flex items-center gap-2 rounded-full border border-white/40 bg-white/75 px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-on-surface transition hover:-translate-y-0.5 hover:border-primary-200/70 hover:text-primary-600"
                                                 type="button"
                                                 on:click={() => goto('/')}
                                         >
@@ -135,8 +135,8 @@
                                 <button
                                         class={`inline-flex items-center justify-center gap-2 rounded-full px-4 py-1.5 text-sm font-semibold transition ${
                                                 $favourites.includes(favouriteKey)
-                                                        ? 'bg-gradient-to-r from-primary-500 to-secondary-500 text-white shadow-lg shadow-primary-500/30'
-                                                        : 'border border-white/60 bg-white/70 text-on-surface hover:border-primary-200/70 hover:text-primary-600'
+                                                        ? 'bg-gradient-to-r from-primary-500 via-primary-600 to-secondary-500 text-white shadow-[0_20px_36px_rgba(14,165,233,0.28)]'
+                                                        : 'border border-white/50 bg-white/80 text-on-surface hover:border-primary-200/70 hover:text-primary-600'
                                         }`}
                                         type="button"
                                         aria-pressed={$favourites.includes(favouriteKey)}
@@ -166,11 +166,11 @@
                                                 {$t('app.page_label')}
                                                 {song.page}
                                         </span>
-                                        <span class="rounded-full border border-white/60 bg-white/60 px-3 py-1 text-[11px] text-on-surface-soft">
+                                        <span class="rounded-full border border-white/50 bg-white/70 px-3 py-1 text-[11px] text-on-surface-soft">
                                                 {$t('app.source_label')}
                                                 {song.source}
                                         </span>
-                                        <span class="rounded-full border border-white/60 bg-white/60 px-3 py-1 text-[11px] text-on-surface-soft">
+                                        <span class="rounded-full border border-white/50 bg-white/70 px-3 py-1 text-[11px] text-on-surface-soft">
                                                 {$t('app.external_index')}
                                                 {song.externalIndex}
                                         </span>
@@ -182,11 +182,11 @@
 				role="tablist"
 				aria-label={$t('app.view_song')}
 			>
-				<button
+                                <button
                                         class={`inline-flex items-center justify-center gap-2 rounded-full px-4 py-1.5 text-sm font-semibold transition ${
                                                 activeViewMode === 'basic'
                                                         ? 'bg-gradient-to-r from-primary-500 to-secondary-500 text-white shadow-lg shadow-primary-500/30'
-                                                        : 'border border-white/60 bg-white/70 text-on-surface'
+                                                        : 'border border-white/50 bg-white/80 text-on-surface'
                                         }`}
 					type="button"
 					role="tab"
@@ -197,11 +197,11 @@
 				>
 					{$t('app.view.basic')}
 				</button>
-				<button
+                                <button
                                         class={`inline-flex items-center justify-center gap-2 rounded-full px-4 py-1.5 text-sm font-semibold transition ${
                                                 activeViewMode === 'chords'
                                                         ? 'bg-gradient-to-r from-primary-500 to-secondary-500 text-white shadow-lg shadow-primary-500/30'
-                                                        : 'border border-white/60 bg-white/70 text-on-surface'
+                                                        : 'border border-white/50 bg-white/80 text-on-surface'
                                         }`}
 					type="button"
 					role="tab"
@@ -216,7 +216,7 @@
 		</header>
 
                 <section
-                        class={`relative space-y-3 rounded-[26px] border border-white/40 bg-white/65 p-5 text-left text-sm leading-relaxed shadow-inner shadow-primary-500/10 sm:p-7 sm:text-base ${
+                        class={`relative space-y-3 rounded-[26px] border border-white/40 bg-white/75 p-5 text-left text-sm leading-relaxed shadow-inner shadow-primary-500/10 sm:p-7 sm:text-base ${
                                 activeViewMode === 'chords' ? 'lg:grid lg:grid-cols-[160px,1fr] lg:gap-6 lg:space-y-0' : ''
                         }`}
                 >


### PR DESCRIPTION
## Summary
- refresh the global color tokens and background treatments for a cooler blue-violet theme that feels cohesive across surfaces
- streamline header, list filters, song cards, and song detail layouts with tighter mobile spacing, lighter borders, and gradient accents
- update translations and search overlay interactions so selecting a result navigates immediately without stale content and the "Zobacz pieśń" label no longer appears

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68db2a8ed5588327ba580ac727a81225