### PR TITLE
Enhance hero section contrast with gold accents

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -39,10 +39,12 @@
         --on-surface: 18 30 39;
         --on-primary: 255 255 255;
 
+        --accent-gold: 234 179 8;
         --hero-gradient-from: 240 249 255;
+        --hero-gradient-mid: 255 247 237;
         --hero-gradient-to: 253 244 255;
-        --hero-glow-primary: 186 230 253;
-        --hero-glow-secondary: 235 180 252;
+        --hero-glow-primary: 253 224 130;
+        --hero-glow-secondary: 186 230 253;
         --overlay-backdrop: 9 16 26;
 }
 
@@ -53,7 +55,8 @@
 
         body {
                 font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-                background: radial-gradient(140% 120% at 10% 0%, rgb(var(--hero-gradient-from) / 0.65), transparent 60%),
+                background: radial-gradient(120% 110% at 15% -5%, rgb(var(--accent-gold) / 0.18), transparent 60%),
+                        radial-gradient(140% 120% at 10% 0%, rgb(var(--hero-gradient-from) / 0.65), transparent 60%),
                         radial-gradient(110% 130% at 90% 10%, rgb(var(--hero-gradient-to) / 0.55), transparent 65%),
                         linear-gradient(180deg, rgb(var(--color-surface-50)) 0%, rgb(var(--color-surface-100)) 100%);
                 color: rgb(var(--on-surface));

--- a/src/lib/components/layout/AppHeader.svelte
+++ b/src/lib/components/layout/AppHeader.svelte
@@ -44,24 +44,27 @@
 
 <section class="pt-6 sm:pt-12 lg:pt-16">
         <div
-                class="relative overflow-hidden rounded-3xl border border-white/40 bg-white/70 p-4 shadow-[0_24px_70px_rgba(15,23,42,0.1)] backdrop-blur-2xl sm:p-6"
+                class="relative overflow-hidden rounded-3xl border border-white/60 bg-white/80 p-4 shadow-[0_24px_70px_rgba(15,23,42,0.12)] backdrop-blur-2xl sm:p-6"
         >
                 <div class="pointer-events-none absolute inset-0 -z-10">
                         <div
-                                class="absolute inset-0 bg-[linear-gradient(140deg,rgb(var(--hero-gradient-from))_0%,rgba(255,255,255,0.92)_55%,rgb(var(--hero-gradient-to))_100%)]"
+                                class="absolute inset-0 bg-[linear-gradient(135deg,rgba(255,255,255,0.94)_0%,rgba(var(--accent-gold),0.28)_45%,rgba(var(--hero-gradient-to),0.82)_100%)]"
                         ></div>
                         <div
-                                class="absolute -top-24 right-6 h-56 w-56 rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-primary)/0.45),rgba(255,255,255,0))] blur-3xl"
+                                class="absolute -top-24 right-6 h-56 w-56 rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-primary)/0.55),rgba(255,255,255,0))] blur-3xl"
                         ></div>
                         <div
-                                class="absolute bottom-[-28%] left-[-12%] h-64 w-64 rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-secondary)/0.5),rgba(255,255,255,0))] blur-3xl"
+                                class="absolute bottom-[-28%] left-[-12%] h-64 w-64 rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-secondary)/0.6),rgba(255,255,255,0))] blur-3xl"
+                        ></div>
+                        <div
+                                class="absolute bottom-[18%] right-[-8%] h-52 w-52 rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--accent-gold)/0.45),rgba(255,255,255,0))] blur-[120px]"
                         ></div>
                 </div>
 
                 <div class="relative flex flex-col gap-8">
                         <div class="flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between">
                                 <div class="space-y-4 text-center lg:max-w-2xl lg:text-left">
-                                        <div class="inline-flex items-center gap-2 self-center rounded-full bg-primary-50/80 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-primary-600 shadow-sm shadow-primary-500/20 lg:self-start">
+                                        <div class="inline-flex items-center gap-2 self-center rounded-full border border-[rgb(var(--accent-gold)/0.4)] bg-[rgb(var(--accent-gold)/0.15)] px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-[rgb(var(--accent-gold)/0.95)] shadow-sm shadow-[rgba(234,179,8,0.25)] lg:self-start">
                                                 {$t('app.brand_global')}
                                         </div>
                                         <div class="space-y-2">
@@ -71,7 +74,7 @@
                                         </div>
                                 </div>
                                 <div class="flex w-full flex-col lg:max-w-sm">
-                                        <div class="rounded-2xl border border-white/50 bg-white/80 p-4 shadow-lg shadow-primary-500/10 backdrop-blur">
+                                        <div class="rounded-2xl border border-white/60 bg-white/80 p-4 shadow-lg shadow-primary-500/10 backdrop-blur">
                                                 <div class="flex items-center justify-between gap-3 text-xs font-semibold uppercase tracking-[0.22em] text-on-surface-subtle">
                                                         <span class="inline-flex items-center gap-2 text-on-surface">
                                                                 <Languages class="h-4 w-4 text-primary-500" />
@@ -83,8 +86,8 @@
                                                                 <button
                                                                         class={`rounded-xl px-3 py-2 text-center text-[11px] font-semibold uppercase tracking-[0.2em] transition ${
                                                                                 $language === option.code
-                                                                                        ? 'bg-gradient-to-r from-primary-500 to-secondary-500 text-white shadow-lg shadow-primary-500/40'
-                                                                                        : 'bg-white/70 text-on-surface hover:bg-primary-50 hover:text-primary-600'
+                                                                                        ? 'bg-gradient-to-r from-[rgb(var(--accent-gold))] via-primary-500 to-secondary-500 text-white shadow-lg shadow-primary-500/40'
+                                                                                        : 'bg-white/70 text-on-surface hover:bg-[rgb(var(--accent-gold)/0.12)] hover:text-primary-600'
                                                                         }`}
                                                                         type="button"
                                                                         aria-pressed={$language === option.code}
@@ -102,7 +105,7 @@
                         <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                                 <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
                                         <button
-                                                class="inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-primary-500 via-primary-600 to-secondary-500 px-5 py-2.5 text-sm font-semibold text-white shadow-[0_14px_28px_rgba(14,165,233,0.32)] transition hover:scale-[1.01] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+                                                class="inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-[rgb(var(--accent-gold))] via-primary-500 to-secondary-500 px-5 py-2.5 text-sm font-semibold text-white shadow-[0_16px_32px_rgba(234,179,8,0.24)] transition hover:scale-[1.01] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgb(var(--accent-gold))]"
                                                 on:click={focusSearch}
                                                 type="button"
                                         >
@@ -111,10 +114,10 @@
                                         </button>
                                 </div>
                                 <div class="flex flex-col gap-2 text-xs text-on-surface-soft sm:flex-row sm:items-center sm:gap-3">
-                                        <div class="inline-flex items-center gap-3 rounded-full border border-white/40 bg-white/70 px-4 py-2 font-semibold uppercase tracking-[0.2em] text-on-surface">
+                                        <div class="inline-flex items-center gap-3 rounded-full border border-white/60 bg-white/75 px-4 py-2 font-semibold uppercase tracking-[0.2em] text-on-surface">
                                                 {$syncStatus}
                                         </div>
-                                        <div class="inline-flex items-center gap-3 rounded-full border border-white/40 bg-white/70 px-4 py-2 font-semibold uppercase tracking-[0.2em] text-on-surface">
+                                        <div class="inline-flex items-center gap-3 rounded-full border border-white/60 bg-white/75 px-4 py-2 font-semibold uppercase tracking-[0.2em] text-on-surface">
                                                 <span class="text-on-surface-muted">{$t('app.last_synced')}</span>
                                                 <span class="text-on-surface">
                                                         {$lastSynced ? new Date($lastSynced).toLocaleString() : '—'}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -63,13 +63,16 @@
 <div class="relative min-h-screen overflow-hidden text-on-surface">
         <div class="pointer-events-none absolute inset-0 -z-10">
                 <div
-                        class="absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.92)_0%,rgba(255,255,255,0.78)_40%,rgba(255,255,255,0.88)_100%)]"
+                        class="absolute inset-0 bg-[linear-gradient(190deg,rgba(255,255,255,0.95)_0%,rgba(var(--hero-gradient-mid),0.58)_38%,rgba(255,255,255,0.9)_100%)]"
                 ></div>
                 <div
-                        class="absolute left-[8%] top-[-16%] h-[22rem] w-[22rem] rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-secondary)/0.5),rgba(255,255,255,0))] blur-[140px]"
+                        class="absolute left-[8%] top-[-16%] h-[22rem] w-[22rem] rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-secondary)/0.55),rgba(255,255,255,0))] blur-[140px]"
                 ></div>
                 <div
-                        class="absolute right-[-12%] top-[0%] h-[28rem] w-[28rem] rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-primary)/0.55),rgba(255,255,255,0))] blur-[150px]"
+                        class="absolute right-[-12%] top-[0%] h-[28rem] w-[28rem] rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--hero-glow-primary)/0.65),rgba(255,255,255,0))] blur-[150px]"
+                ></div>
+                <div
+                        class="absolute bottom-[8%] right-[12%] h-[20rem] w-[20rem] rounded-full bg-[radial-gradient(circle_at_center,rgb(var(--accent-gold)/0.42),rgba(255,255,255,0))] blur-[140px]"
                 ></div>
                 <div
                         class="absolute bottom-[-26%] left-1/2 h-[28rem] w-[28rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,rgba(255,255,255,0.92),rgba(255,255,255,0))] blur-[170px]"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -96,7 +96,7 @@
 
 <section class="space-y-6 pb-14 sm:space-y-8">
         <div
-                class="space-y-5 rounded-3xl border border-white/40 bg-white/80 p-4 shadow-[0_25px_70px_rgba(15,23,42,0.08)] backdrop-blur-2xl sm:p-6"
+                class="space-y-5 rounded-3xl border border-white/60 bg-[linear-gradient(160deg,rgba(255,255,255,0.96)_0%,rgba(255,255,255,0.86)_100%)] p-4 shadow-[0_25px_70px_rgba(15,23,42,0.1)] backdrop-blur-2xl sm:p-6"
                 use:fadeSlide
         >
 		<div class="space-y-2">
@@ -107,7 +107,7 @@
         {$t('app.search_placeholder')}
       </label> -->
                         <div
-                                class="flex items-center gap-3 rounded-2xl border border-white/40 bg-white/70 px-4 py-3 shadow-inner shadow-primary-500/10"
+                                class="flex items-center gap-3 rounded-2xl border border-white/60 bg-[rgba(255,255,255,0.9)] px-4 py-3 shadow-inner shadow-[rgba(14,165,233,0.12)]"
                         >
                                 <Search class="h-4 w-4 text-primary-500" />
                                 <input
@@ -120,7 +120,7 @@
 				/>
                                 {#if query}
                                         <button
-                                                class="rounded-full bg-white/80 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-primary-600 shadow-sm transition hover:bg-white"
+                                                class="rounded-full border border-white/70 bg-white/90 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-primary-600 shadow-sm transition hover:bg-[rgb(var(--accent-gold)/0.16)] hover:text-[rgb(var(--accent-gold)/0.9)]"
                                                 on:click={() => (query = '')}
                                                 type="button"
                                         >
@@ -136,8 +136,8 @@
 			<span>/</span>
 			<span>{availableSongs.length}</span>
 			{#if pageFilter}
-				<span
-                                        class="rounded-full bg-primary-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-primary-500"
+                                <span
+                                        class="rounded-full border border-[rgb(var(--accent-gold)/0.4)] bg-[rgb(var(--accent-gold)/0.16)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-[rgb(var(--accent-gold)/0.95)]"
                                 >
                                         {$t('app.page_label')}
                                         {pageFilter}
@@ -149,7 +149,7 @@
                         <div class="flex flex-wrap gap-2">
                                 {#each filterBadges as badge}
                                         <span
-                                                class="inline-flex items-center gap-2 rounded-full border border-primary-100/70 bg-primary-50/90 px-3 py-1 text-xs font-semibold text-primary-600 shadow-sm"
+                                                class="inline-flex items-center gap-2 rounded-full border border-[rgb(var(--accent-gold)/0.35)] bg-[rgb(var(--accent-gold)/0.12)] px-3 py-1 text-xs font-semibold text-[rgb(var(--accent-gold)/0.95)] shadow-sm"
                                         >
                                                 {badge}
                                         </span>
@@ -159,7 +159,7 @@
         </div>
 
         <div
-                class="space-y-5 rounded-3xl border border-white/40 bg-white/80 p-4 shadow-[0_25px_70px_rgba(15,23,42,0.08)] backdrop-blur-2xl sm:p-6"
+                class="space-y-5 rounded-3xl border border-white/60 bg-[linear-gradient(160deg,rgba(255,255,255,0.96)_0%,rgba(255,255,255,0.86)_100%)] p-4 shadow-[0_25px_70px_rgba(15,23,42,0.1)] backdrop-blur-2xl sm:p-6"
                 use:fadeSlide={{ axis: 'y', from: 30, delay: 0.05 }}
         >
                 <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
@@ -167,8 +167,8 @@
                                 <button
                                         class={`inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-sm font-semibold transition ${
                                                 menuView === 'index'
-                                                        ? 'bg-gradient-to-r from-primary-500 to-secondary-500 text-white shadow-lg shadow-primary-500/30'
-                                                        : 'border border-white/50 bg-white/70 text-on-surface hover:border-primary-200/70 hover:text-primary-600'
+                                                        ? 'bg-gradient-to-r from-[rgb(var(--accent-gold))] via-primary-500 to-secondary-500 text-white shadow-lg shadow-primary-500/30'
+                                                        : 'border border-white/60 bg-white/75 text-on-surface hover:border-[rgb(var(--accent-gold)/0.45)] hover:text-primary-600'
                                         }`}
                                         on:click={() => (menuView = 'index')}
                                         type="button"
@@ -179,8 +179,8 @@
                                 <button
                                         class={`inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-sm font-semibold transition ${
                                                 menuView === 'favourites'
-                                                        ? 'bg-gradient-to-r from-primary-500 to-secondary-500 text-white shadow-lg shadow-primary-500/30'
-                                                        : 'border border-white/50 bg-white/70 text-on-surface hover:border-primary-200/70 hover:text-primary-600'
+                                                        ? 'bg-gradient-to-r from-[rgb(var(--accent-gold))] via-primary-500 to-secondary-500 text-white shadow-lg shadow-primary-500/30'
+                                                        : 'border border-white/60 bg-white/75 text-on-surface hover:border-[rgb(var(--accent-gold)/0.45)] hover:text-primary-600'
                                         }`}
                                         on:click={() => (menuView = 'favourites')}
                                         type="button"
@@ -189,7 +189,7 @@
 					{$t('app.toggle_favourites')}
 				</button>
                                 <button
-                                        class="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/70 px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-on-surface-muted transition hover:border-primary-200/70 hover:text-primary-600"
+                                        class="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/75 px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-on-surface-muted transition hover:border-[rgb(var(--accent-gold)/0.45)] hover:text-[rgb(var(--accent-gold)/0.95)]"
                                         on:click={handleClearFilters}
                                         type="button"
                                 >


### PR DESCRIPTION
## Summary
- introduce a reusable accent gold color and update global gradients for more contrast
- refresh the hero header background, buttons, and chips with gold-infused gradients and clearer borders
- adjust search panels and filter badges to improve readability against the bright background

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dbab685b308327bbb6e041e7105543