### PR TITLE
Improve button visibility and icon-only controls

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -73,9 +73,9 @@
         .btn-gold {
                 background: linear-gradient(
                         120deg,
-                        rgba(var(--accent-gold), 0.85) 0%,
-                        rgba(var(--accent-gold), 0.82) 68%,
-                        rgba(var(--color-primary-600), 0.88) 100%
+                        rgba(var(--accent-gold), 1) 0%,
+                        rgba(var(--accent-gold), 0.98) 68%,
+                        rgba(var(--color-primary-600), 0.98) 100%
                 );
                 color: rgb(var(--on-surface));
                 box-shadow: 0 20px 42px rgba(var(--accent-gold), 0.18);
@@ -89,9 +89,9 @@
         .btn-gold:hover {
                 background: linear-gradient(
                         120deg,
-                        rgba(var(--accent-gold), 0.88) 0%,
-                        rgba(var(--accent-gold), 0.84) 72%,
-                        rgba(var(--color-primary-600), 0.92) 100%
+                        rgba(var(--accent-gold), 1) 0%,
+                        rgba(var(--accent-gold), 1) 72%,
+                        rgba(var(--color-primary-600), 1) 100%
                 );
                 box-shadow: 0 24px 52px rgba(var(--accent-gold), 0.22);
                 transform: translateY(-1px);
@@ -100,5 +100,59 @@
         .btn-gold:focus-visible {
                 outline: 2px solid rgba(var(--accent-gold), 0.6);
                 outline-offset: 2px;
+        }
+
+        .icon-button {
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                width: 2.75rem;
+                height: 2.75rem;
+                border-radius: 9999px;
+                border: 1px solid rgba(255, 255, 255, 0.7);
+                background-color: rgba(255, 255, 255, 0.96);
+                color: rgb(var(--on-surface));
+                box-shadow: 0 14px 36px rgba(15, 23, 42, 0.12);
+                transition: transform 180ms cubic-bezier(0.22, 1, 0.36, 1),
+                        box-shadow 180ms cubic-bezier(0.22, 1, 0.36, 1),
+                        border-color 180ms ease,
+                        background-color 180ms ease,
+                        color 180ms ease;
+        }
+
+        .icon-button:hover {
+                transform: translateY(-1px);
+                border-color: rgba(var(--accent-gold), 0.5);
+                box-shadow: 0 20px 44px rgba(15, 23, 42, 0.16);
+                color: rgb(var(--color-primary-600));
+        }
+
+        .icon-button:focus-visible {
+                outline: 2px solid rgba(var(--accent-gold), 0.6);
+                outline-offset: 2px;
+        }
+
+        .icon-button--success {
+                background-color: rgba(16, 185, 129, 0.16);
+                border-color: rgba(16, 185, 129, 0.35);
+                color: rgb(5, 150, 105);
+                box-shadow: 0 18px 42px rgba(16, 185, 129, 0.18);
+        }
+
+        .icon-button--success:hover {
+                border-color: rgba(16, 185, 129, 0.45);
+                box-shadow: 0 22px 48px rgba(16, 185, 129, 0.22);
+        }
+
+        .icon-button--danger {
+                background-color: rgba(248, 113, 113, 0.16);
+                border-color: rgba(248, 113, 113, 0.35);
+                color: rgb(220, 38, 38);
+                box-shadow: 0 18px 42px rgba(248, 113, 113, 0.18);
+        }
+
+        .icon-button--danger:hover {
+                border-color: rgba(248, 113, 113, 0.45);
+                box-shadow: 0 22px 48px rgba(248, 113, 113, 0.22);
         }
 }

--- a/src/lib/components/layout/AppHeader.svelte
+++ b/src/lib/components/layout/AppHeader.svelte
@@ -117,7 +117,7 @@
                                         <div class="inline-flex items-center gap-3 rounded-full border border-white/60 bg-white/75 px-4 py-2 font-semibold uppercase tracking-[0.2em] text-on-surface">
                                                 {$syncStatus}
                                         </div>
-                                        <div class="inline-flex items-center gap-3 rounded-full border border-white/60 bg-white/75 px-4 py-2 font-semibold uppercase tracking-[0.2em] text-on-surface">
+                                        <div class="inline-flex items-center gap-3 rounded-full border border-white/60 bg-white/75 px-4 py-2 font-semibold uppercase tracking-[0.12em] text-on-surface">
                                                 <span class="text-on-surface-muted">{$t('app.last_synced')}</span>
                                                 <span class="text-on-surface">
                                                         {$lastSynced ? new Date($lastSynced).toLocaleString() : '—'}

--- a/src/lib/components/song/SongCard.svelte
+++ b/src/lib/components/song/SongCard.svelte
@@ -5,7 +5,7 @@
 	import { t } from 'svelte-i18n';
 	import { listTransition } from '$lib/actions/listTransition';
 	import { inView } from '$lib/actions/inView';
-	import { Heart, ExternalLink, Eye, EyeOff, Link2 } from 'lucide-svelte';
+import { AlertCircle, Check, ExternalLink, Eye, EyeOff, Heart, Link2 } from 'lucide-svelte';
 	import type { Song } from '$lib/types/song';
 
 	export let song: Song;
@@ -128,19 +128,20 @@
                                                 </span>
                                         </div>
 					</div>
-					<div class="flex flex-wrap justify-end gap-2 text-sm">
+                                        <div class="flex flex-wrap justify-end gap-2.5 text-sm">
                                                 <button
-                                                        class={`inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-sm font-medium transition ${
-                                                                isFavourite
-                                                                        ? 'btn-gold'
-                                                                        : 'border border-white/50 bg-white/80 text-on-surface hover:border-primary-200/70 hover:text-primary-600'
-                                                        }`}
+                                                        class={`icon-button ${isFavourite ? 'btn-gold' : ''}`}
                                                         on:click={() => dispatch('toggleFavourite', `${song.id}-${song.language}`)}
                                                         type="button"
+                                                        aria-pressed={isFavourite}
+                                                        aria-label={isFavourite ? $t('app.remove_favourite') : $t('app.add_favourite')}
+                                                        title={isFavourite ? $t('app.remove_favourite') : $t('app.add_favourite')}
                                                 >
-							<Heart class={`h-4 w-4 ${isFavourite ? 'fill-current' : ''}`} />
-							{isFavourite ? $t('app.remove_favourite') : $t('app.add_favourite')}
-						</button>
+                                                        <Heart class={`h-5 w-5 transition ${isFavourite ? 'fill-current' : ''}`} />
+                                                        <span class="sr-only">
+                                                                {isFavourite ? $t('app.remove_favourite') : $t('app.add_favourite')}
+                                                        </span>
+                                                </button>
                                                 <button
                                                         class="btn-gold inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-sm font-semibold transition"
                                                         on:click={() => dispatch('open', song)}
@@ -148,32 +149,69 @@
                                                 >
                                                         <ExternalLink class="h-4 w-4" />
                                                         {$t('app.go_to_song')}
-						</button>
-						{#if remainingItems.length}
+                                                </button>
+                                                {#if remainingItems.length}
                                                         <button
-                                                                class="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/80 px-3.5 py-1.5 text-sm font-medium text-on-surface transition hover:border-primary-200/70 hover:text-primary-600"
+                                                                class="icon-button"
                                                                 on:click={() => (expanded = !expanded)}
                                                                 type="button"
                                                                 aria-expanded={expanded}
+                                                                aria-label={expanded ? $t('app.hide_preview') : $t('app.preview')}
+                                                                title={expanded ? $t('app.hide_preview') : $t('app.preview')}
                                                         >
-								{#if expanded}
-									<EyeOff class="h-4 w-4" />
-									{$t('app.hide_preview')}
-								{:else}
-									<Eye class="h-4 w-4" />
-									{$t('app.preview')}
-								{/if}
-							</button>
-						{/if}
+                                                                {#if expanded}
+                                                                        <EyeOff class="h-5 w-5" />
+                                                                {:else}
+                                                                        <Eye class="h-5 w-5" />
+                                                                {/if}
+                                                                <span class="sr-only">
+                                                                        {expanded ? $t('app.hide_preview') : $t('app.preview')}
+                                                                </span>
+                                                        </button>
+                                                {/if}
                                                 <button
-                                                        class="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/80 px-3.5 py-1.5 text-sm font-medium text-on-surface transition hover:border-primary-200/70 hover:text-primary-600"
+                                                        class={`icon-button ${
+                                                                copyState === 'copied'
+                                                                        ? 'icon-button--success'
+                                                                        : copyState === 'error'
+                                                                                ? 'icon-button--danger'
+                                                                                : ''
+                                                        }`}
                                                         on:click={copyShareLink}
                                                         type="button"
+                                                        aria-label={
+                                                                copyState === 'copied'
+                                                                        ? $t('app.copied_link')
+                                                                        : copyState === 'error'
+                                                                                ? $t('app.copy_failed')
+                                                                                : $t('app.copy_link')
+                                                        }
+                                                        title={
+                                                                copyState === 'copied'
+                                                                        ? $t('app.copied_link')
+                                                                        : copyState === 'error'
+                                                                                ? $t('app.copy_failed')
+                                                                                : $t('app.copy_link')
+                                                        }
                                                 >
-							<Link2 class="h-4 w-4" />
-							{copyState === 'copied' ? $t('app.copied_link') : $t('app.copy_link')}
-						</button>
-					</div>
+                                                        {#if copyState === 'copied'}
+                                                                <Check class="h-5 w-5" />
+                                                        {:else if copyState === 'error'}
+                                                                <AlertCircle class="h-5 w-5" />
+                                                        {:else}
+                                                                <Link2 class="h-5 w-5" />
+                                                        {/if}
+                                                        <span class="sr-only" aria-live="polite">
+                                                                {#if copyState === 'copied'}
+                                                                        {$t('app.copied_link')}
+                                                                {:else if copyState === 'error'}
+                                                                        {$t('app.copy_failed')}
+                                                                {:else}
+                                                                        {$t('app.copy_link')}
+                                                                {/if}
+                                                        </span>
+                                                </button>
+                                        </div>
 				</div>
 
 				<!-- <div class="rounded-xl border border-surface-200/70 bg-white px-4 py-4 text-xs">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -313,11 +313,13 @@
 
 {#if showScrollTop}
         <button
-                class="btn-gold fixed bottom-6 right-5 z-40 inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold"
+                class="btn-gold icon-button fixed bottom-6 right-5 z-40"
                 on:click={scrollToTop}
                 type="button"
+                aria-label={$t('app.scroll_to_top')}
+                title={$t('app.scroll_to_top')}
         >
-                <ArrowUp class="h-4 w-4" />
-                <span>{$t('app.scroll_to_top')}</span>
+                <ArrowUp class="h-5 w-5" />
+                <span class="sr-only">{$t('app.scroll_to_top')}</span>
         </button>
 {/if}

--- a/src/routes/song/[id]/+page.svelte
+++ b/src/routes/song/[id]/+page.svelte
@@ -4,7 +4,7 @@
         import { page } from '$app/stores';
         import { t } from 'svelte-i18n';
         import { onMount } from 'svelte';
-        import { ArrowUp } from 'lucide-svelte';
+        import { ArrowUp, Heart } from 'lucide-svelte';
         import { getSongByKey } from '$lib/stores/songStore';
         import { favourites, toggleFavourite, language, viewMode } from '$lib/stores/preferences';
         import type { Song, SongLanguage } from '$lib/types/song';
@@ -152,19 +152,34 @@
                                         </button>
                                 </div>
                                 <button
-                                        class={`inline-flex items-center justify-center gap-2 rounded-full px-4 py-1.5 text-sm font-semibold transition ${
+                                        class={`icon-button ${
                                                 $favourites.includes(favouriteKey)
                                                         ? 'btn-gold'
-                                                        : 'border border-white/50 bg-white/80 text-on-surface hover:border-primary-200/70 hover:text-primary-600'
+                                                        : ''
                                         }`}
                                         type="button"
                                         aria-pressed={$favourites.includes(favouriteKey)}
+                                        aria-label={$favourites.includes(favouriteKey)
+                                                ? $t('app.remove_favourite')
+                                                : $t('app.add_favourite')}
+                                        title={$favourites.includes(favouriteKey)
+                                                ? $t('app.remove_favourite')
+                                                : $t('app.add_favourite')}
                                         on:click={() => toggleFavourite(favouriteKey)}
                                 >
-					{$favourites.includes(favouriteKey)
-						? $t('app.remove_favourite')
-						: $t('app.add_favourite')}
-				</button>
+                                        <Heart
+                                                class={`h-5 w-5 transition ${
+                                                        $favourites.includes(favouriteKey)
+                                                                ? 'fill-current'
+                                                                : ''
+                                                }`}
+                                        />
+                                        <span class="sr-only">
+                                                {$favourites.includes(favouriteKey)
+                                                        ? $t('app.remove_favourite')
+                                                        : $t('app.add_favourite')}
+                                        </span>
+                                </button>
 			</div>
 
 			<div class="space-y-3">
@@ -265,12 +280,14 @@
         </article>
         {#if showScrollTop}
                 <button
-                        class="btn-gold fixed bottom-6 right-5 z-40 inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold"
+                        class="btn-gold icon-button fixed bottom-6 right-5 z-40"
                         type="button"
+                        aria-label={$t('app.scroll_to_top')}
+                        title={$t('app.scroll_to_top')}
                         on:click={scrollToTop}
                 >
-                        <ArrowUp class="h-4 w-4" />
-                        <span>{$t('app.scroll_to_top')}</span>
+                        <ArrowUp class="h-5 w-5" />
+                        <span class="sr-only">{$t('app.scroll_to_top')}</span>
                 </button>
         {/if}
 {:else}


### PR DESCRIPTION
## Summary
- make the gold button background fully opaque and add reusable icon-button styles for stronger affordances
- convert favourite, preview, share, and scroll-to-top actions to icon-only buttons with accessible labels and state feedback
- tighten the "last synced" label tracking so the polish copy reads comfortably

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dbe02ba9488327a802a68c290fea8c