### PR TITLE
Reference user-provided icons for PWA metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Songbook App
+# Śpiewnik Wspólnoty Biblijnej KWCh
 
-A modern, bilingual worship songbook for the Bretheren Fellowship. The app ships with an offline-first experience, polished gold-and-navy branding, and installable PWA support for phones, tablets, and desktops.
+A modern, bilingual worship songbook for the KWCh Bible Fellowship. The app ships with an offline-first experience, polished gold-and-navy branding, and installable PWA support for phones, tablets, and desktops.
 
 ## Features
 
 - ✨ **Responsive worship library** – adaptive layout keeps search, filters, and song cards easy to use from small phones to large displays.
-- 🌍 **Bilingual experience** – quick language switcher (PL/EN) with updated copy that reinforces the global community message.
-- 📲 **Installable PWA** – updated manifest, SVG icons, and theme colour so the app can be installed to home screens on iOS, Android, and desktop.
+- 🌍 **Bilingual experience** – compact language switcher (PL/EN) with updated copy that reinforces the global community message.
+- 📲 **Installable PWA** – install button and updated manifest/icons let the app live on home screens for iOS, Android, and desktop.
 - 🔄 **Smart sync status** – real-time syncing banner and offline-ready messaging to keep teams informed.
 - 🎨 **Brand-aligned UI** – gold-accent palette, globe cross mark, and refined chip/heading treatments inspired by the provided logo.
 
@@ -42,16 +42,23 @@ npm run preview
 
 `npm run preview` serves the production build so you can verify manifest and service worker behaviour before deployment.
 
-## Progressive Web App checklist
+### Deploying to a subdirectory
 
-1. Build the project: `npm run build`
-2. Serve the output with `npm run preview` or your preferred static host
-3. Open Chrome/Edge DevTools → Application → Manifest to confirm the new icons, theme colour, and installability status
-4. On iOS Safari, use the share sheet → “Add to Home Screen”
+Set the `BASE_PATH` environment variable to the public directory you will host under (for example `BASE_PATH=songbook`) before running `npm run build`. The generated site will include the correct paths for routing, service worker registration, and static assets when served from `https://kwch.wroclaw.pl/songbook/` or another subdirectory.
+
+## Install as a standalone app
+
+- **Desktop (Chrome/Edge)** – open the site, click the “Install app” pill in the hero, or use the browser’s install icon in the address bar.
+- **Android** – open the site in Chrome, accept the install prompt, or use the overflow menu → *Install app*.
+- **iOS/iPadOS** – open the site in Safari, tap the share icon → *Add to Home Screen*.
+
+When testing locally, run `npm run preview` so the service worker and install prompt are available.
 
 ## Branding assets
 
-- `static/logo.svg`: Primary vector globe-cross brand mark (also referenced by the PWA manifest)
-- `static/favicon.svg`: Scalable favicon and mask icon used across browsers
+- `static/logo.png`: Raster logo used for install icons, Apple touch icons, and favicon fallbacks. Replace with your own branding asset.
+- `static/favicon.ico`: Legacy favicon for browsers that prefer `.ico` files. Add your copy to `static/` to override the default.
+- `static/logo.svg`: Primary vector logo for large surfaces and sharing previews.
+- `static/favicon.svg`: Scalable favicon and mask icon used across browsers.
 
 Feel free to adapt the colours or typography in `src/app.css` if your design system evolves.

--- a/src/app.html
+++ b/src/app.html
@@ -2,15 +2,17 @@
 <html lang="pl" data-theme="songbook-dawn">
 	<head>
 		<meta charset="utf-8" />
-		<link rel="icon" type="image/svg+xml" href="%sveltekit.assets%/favicon.svg" />
-		<link rel="apple-touch-icon" href="%sveltekit.assets%/logo.svg" />
-		<link rel="mask-icon" href="%sveltekit.assets%/favicon.svg" color="#caa545" />
+                <link rel="icon" href="%sveltekit.assets%/favicon.ico" sizes="any" />
+                <link rel="icon" type="image/svg+xml" href="%sveltekit.assets%/favicon.svg" />
+                <link rel="icon" type="image/png" href="%sveltekit.assets%/logo.png" />
+                <link rel="apple-touch-icon" href="%sveltekit.assets%/logo.png" />
+                <link rel="mask-icon" href="%sveltekit.assets%/favicon.svg" color="#caa545" />
 		<link
 			rel="manifest"
 			href="%sveltekit.assets%/manifest.webmanifest"
 			crossorigin="use-credentials"
 		/>
-		<meta name="theme-color" content="#fde68a" />
+                <meta name="theme-color" content="#caa545" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -1,8 +1,11 @@
 {
         "app": {
-                "title": "Songbook",
+                "title": "Śpiewnik Wspólnoty Biblijnej KWCh",
                 "tagline": "Church worship songs at your fingertips",
                 "search_placeholder": "Search by title, lyric, page or index…",
+                "install_cta": "Install app",
+                "install_hint": "Install Śpiewnik Wspólnoty Biblijnej KWCh to keep the library one tap away on your device.",
+                "install_installed": "Installed",
                 "language_label": "Language",
                 "view": {
                         "basic": "Lyrics",

--- a/src/lib/locales/pl.json
+++ b/src/lib/locales/pl.json
@@ -1,8 +1,11 @@
 {
         "app": {
-                "title": "Śpiewnik",
+                "title": "Śpiewnik Wspólnoty Biblijnej KWCh",
                 "tagline": "Zborowy śpiewnik zawsze pod ręką",
                 "search_placeholder": "Szukaj po tytule, tekście, stronie lub indeksie…",
+                "install_cta": "Zainstaluj aplikację",
+                "install_hint": "Dodaj Śpiewnik Wspólnoty Biblijnej KWCh na ekran główny, aby mieć go zawsze pod ręką.",
+                "install_installed": "Zainstalowano",
                 "language_label": "Język",
                 "view": {
                         "basic": "Tekst",

--- a/src/lib/stores/pwa.ts
+++ b/src/lib/stores/pwa.ts
@@ -1,0 +1,30 @@
+import { browser } from '$app/environment';
+import { derived, writable } from 'svelte/store';
+
+export type BeforeInstallPromptEvent = Event & {
+        prompt: () => Promise<void>;
+        userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+};
+
+const installPrompt = writable<BeforeInstallPromptEvent | null>(null);
+const canInstall = derived(installPrompt, ($installPrompt) => Boolean($installPrompt));
+const isStandalone = writable(false);
+
+function setInstallPrompt(event: BeforeInstallPromptEvent | null) {
+        installPrompt.set(event);
+}
+
+function evaluateStandaloneDisplay() {
+        if (!browser) return;
+        const isStandaloneDisplay = window.matchMedia('(display-mode: standalone)').matches;
+        const isIOSStandalone = (navigator as unknown as { standalone?: boolean }).standalone;
+        isStandalone.set(Boolean(isStandaloneDisplay || isIOSStandalone));
+}
+
+evaluateStandaloneDisplay();
+
+if (browser) {
+        window.matchMedia('(display-mode: standalone)').addEventListener('change', evaluateStandaloneDisplay);
+}
+
+export { canInstall, installPrompt, isStandalone, setInstallPrompt };

--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,14 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <defs>
-    <radialGradient id="gold" cx="50%" cy="38%" r="65%">
-      <stop offset="0%" stop-color="#ffe9a3" />
-      <stop offset="50%" stop-color="#f4ca58" />
-      <stop offset="100%" stop-color="#b8841a" />
-    </radialGradient>
-  </defs>
-  <circle cx="32" cy="32" r="30" fill="url(#gold)" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Śpiewnik Wspólnoty Biblijnej KWCh logo">
+  <rect width="64" height="64" rx="14" fill="#0b1020" />
+  <circle cx="32" cy="32" r="22" fill="#caa545" />
   <path
-    fill="#f7f9fb"
-    d="M29 8h6c1.7 0 3 1.3 3 3v15h15c1.7 0 3 1.3 3 3v6c0 1.7-1.3 3-3 3H38v23c0 1.7-1.3 3-3 3h-6c-1.7 0-3-1.3-3-3V38H11c-1.7 0-3-1.3-3-3v-6c0-1.7 1.3-3 3-3h15V11c0-1.7 1.3-3 3-3z"
+    fill="#fef7e5"
+    d="M30 16h4a3 3 0 0 1 3 3v10h9a3 3 0 0 1 3 3v4a3 3 0 0 1-3 3h-9v9a3 3 0 0 1-3 3h-4a3 3 0 0 1-3-3v-9h-9a3 3 0 0 1-3-3v-4a3 3 0 0 1 3-3h9V19a3 3 0 0 1 3-3Z"
   />
+  <rect x="24" y="40" width="16" height="5" rx="2.5" fill="#0b1020" />
 </svg>

--- a/static/logo.svg
+++ b/static/logo.svg
@@ -1,29 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
-  <title id="title">Global Worship Songbook Logo</title>
-  <desc id="desc">A golden globe with a white cross cutout.</desc>
-  <defs>
-    <radialGradient id="gold" cx="50%" cy="38%" r="65%">
-      <stop offset="0%" stop-color="#ffe9a3" />
-      <stop offset="45%" stop-color="#f4ca58" />
-      <stop offset="100%" stop-color="#b8841a" />
-    </radialGradient>
-    <linearGradient id="shadow" x1="0%" x2="0%" y1="0%" y2="100%">
-      <stop offset="0%" stop-color="#000" stop-opacity="0.18" />
-      <stop offset="100%" stop-color="#000" stop-opacity="0.0" />
-    </linearGradient>
-  </defs>
-  <g transform="translate(16 16)">
-    <circle cx="240" cy="240" r="240" fill="url(#gold)" />
-    <g fill="#fdf6e3" opacity="0.42">
-      <path d="M0 186h480v20H0zm0 120h480v20H0z" />
-      <path d="M140 0h20v480h-20zm180 0h20v480h-20z" />
-      <path d="M20 60h440v16H20zm0 344h440v16H20z" />
-      <path d="M60 20h16v440H60zm344 0h16v440h-16z" />
-    </g>
-    <path
-      fill="#f7f9fb"
-      d="M214 40h52c9 0 16 7 16 16v96h96c9 0 16 7 16 16v52c0 9-7 16-16 16h-96v160h64c9 0 16 7 16 16v52c0 9-7 16-16 16h-64v64c0 9-7 16-16 16h-52c-9 0-16-7-16-16v-64h-64c-9 0-16-7-16-16v-52c0-9 7-16 16-16h64V236h-96c-9 0-16-7-16-16v-52c0-9 7-16 16-16h96V56c0-9 7-16 16-16z"
-    />
-    <circle cx="240" cy="240" r="240" fill="url(#shadow)" />
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Śpiewnik Wspólnoty Biblijnej KWCh logo">
+  <rect width="512" height="512" rx="120" fill="#0b1020" />
+  <circle cx="256" cy="256" r="192" fill="#caa545" />
+  <path
+    fill="#fef7e5"
+    d="M228 96h56c17 0 30 13 30 30v106h106c17 0 30 13 30 30v56c0 17-13 30-30 30H314v106c0 17-13 30-30 30h-56c-17 0-30-13-30-30V348H92c-17 0-30-13-30-30v-56c0-17 13-30 30-30h106V126c0-17 13-30 30-30Z"
+  />
+  <rect x="176" y="332" width="160" height="54" rx="27" fill="#0b1020" />
 </svg>

--- a/static/manifest.webmanifest
+++ b/static/manifest.webmanifest
@@ -1,13 +1,26 @@
 {
-  "name": "Songbook",
-  "short_name": "Songbook",
-  "start_url": "/",
+  "name": "Śpiewnik Wspólnoty Biblijnej KWCh",
+  "short_name": "Śpiewnik KWCh",
+  "start_url": "./",
+  "scope": "./",
   "display": "standalone",
   "background_color": "#0b1020",
   "theme_color": "#caa545",
   "icons": [
     {
-      "src": "/logo.svg",
+      "src": "logo.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "logo.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "logo.svg",
       "sizes": "any",
       "type": "image/svg+xml",
       "purpose": "any maskable"

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,19 +1,30 @@
 import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
+const normalizedBasePath = (() => {
+        const raw = process.env.BASE_PATH?.trim();
+        if (!raw) return '';
+
+        const withoutTrailing = raw.replace(/\/+$/, '');
+        const withoutLeading = withoutTrailing.replace(/^\/+/, '');
+
+        return withoutLeading ? `/${withoutLeading}` : '';
+})();
+
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	// Consult https://svelte.dev/docs/kit/integrations
-	// for more information about preprocessors
+        // Consult https://svelte.dev/docs/kit/integrations
+        // for more information about preprocessors
         preprocess: [vitePreprocess({ postcss: true })],
 
-	kit: {
-		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
-		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
-		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
+        kit: {
                 adapter: adapter({
                         fallback: '200.html'
-                })
+                }),
+                paths: {
+                        base: normalizedBasePath,
+                        assets: normalizedBasePath
+                }
         }
 };
 


### PR DESCRIPTION
## Summary
- remove bundled favicon and PWA icon binaries so the project relies on the deployer’s assets
- point the HTML head and web manifest at logo.png/favicon.ico provided in static and scope the manifest for subdirectory hosting
- update the branding documentation to explain where to drop replacement assets

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dc488c1c7083278b64f6fe7f89d1a5