### PR TITLE
Replace SVG favicon and logo references with PNG/ICO assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,8 @@ When testing locally, run `npm run preview` so the service worker and install pr
 
 ## Branding assets
 
-- `static/logo.png`: Raster logo used for install icons, Apple touch icons, and favicon fallbacks. Replace with your own branding asset.
+- `static/logo.png`: Primary logo asset used for install icons, Apple touch icons, and larger surfaces. Replace with your own branding.
 - `static/favicon.ico`: Legacy favicon for browsers that prefer `.ico` files. Add your copy to `static/` to override the default.
-- `static/logo.svg`: Primary vector logo for large surfaces and sharing previews.
-- `static/favicon.svg`: Scalable favicon and mask icon used across browsers.
+- `static/favicon.png`: Modern favicon used across browsers alongside the `.ico` fallback.
 
 Feel free to adapt the colours or typography in `src/app.css` if your design system evolves.

--- a/src/app.html
+++ b/src/app.html
@@ -3,10 +3,9 @@
 	<head>
 		<meta charset="utf-8" />
                 <link rel="icon" href="%sveltekit.assets%/favicon.ico" sizes="any" />
-                <link rel="icon" type="image/svg+xml" href="%sveltekit.assets%/favicon.svg" />
+                <link rel="icon" type="image/png" href="%sveltekit.assets%/favicon.png" />
                 <link rel="icon" type="image/png" href="%sveltekit.assets%/logo.png" />
                 <link rel="apple-touch-icon" href="%sveltekit.assets%/logo.png" />
-                <link rel="mask-icon" href="%sveltekit.assets%/favicon.svg" color="#caa545" />
 		<link
 			rel="manifest"
 			href="%sveltekit.assets%/manifest.webmanifest"

--- a/static/manifest.webmanifest
+++ b/static/manifest.webmanifest
@@ -18,12 +18,6 @@
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"
-    },
-    {
-      "src": "logo.svg",
-      "sizes": "any",
-      "type": "image/svg+xml",
-      "purpose": "any maskable"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- update the app shell to serve PNG and ICO favicons instead of SVG assets
- adjust the PWA manifest and documentation to reference only PNG logo resources

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc5b2dcd888327bd50f406c9a6f5f9