### PR TITLE
Load BASE_PATH from env files

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,8 +1,10 @@
 import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import { loadEnv } from 'vite';
 
 const normalizedBasePath = (() => {
-	const raw = process.env.BASE_PATH?.trim();
+        const env = loadEnv(process.env.NODE_ENV ?? 'development', process.cwd(), '');
+        const raw = (process.env.BASE_PATH ?? env.BASE_PATH)?.trim();
 	if (!raw) return '';
 
 	const withoutTrailing = raw.replace(/\/+$/, '');


### PR DESCRIPTION
## Summary
- load Vite environment files before reading BASE_PATH in the Svelte config
- fall back to an exported BASE_PATH value when computing the normalized base path

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc6699b6788327967cd8e0d78c6184