### PR TITLE
Fix assets path handling for Svelte configuration

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -2,15 +2,33 @@ import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 import { loadEnv } from 'vite';
 
+const env = loadEnv(process.env.NODE_ENV ?? 'development', process.cwd(), '');
+
 const normalizedBasePath = (() => {
-        const env = loadEnv(process.env.NODE_ENV ?? 'development', process.cwd(), '');
         const raw = (process.env.BASE_PATH ?? env.BASE_PATH)?.trim();
-	if (!raw) return '';
+        if (!raw) return '';
 
-	const withoutTrailing = raw.replace(/\/+$/, '');
-	const withoutLeading = withoutTrailing.replace(/^\/+/, '');
+        const withoutTrailing = raw.replace(/\/+$/, '');
+        const withoutLeading = withoutTrailing.replace(/^\/+/, '');
 
-	return withoutLeading ? `/${withoutLeading}` : '';
+        return withoutLeading ? `/${withoutLeading}` : '';
+})();
+
+const normalizedAssetsPath = (() => {
+        const raw = (process.env.ASSETS_PATH ?? env.ASSETS_PATH)?.trim();
+        if (!raw) return undefined;
+
+        const withoutTrailing = raw.replace(/\/+$/, '');
+
+        if (/^(?:[a-zA-Z][a-zA-Z\d+.-]*:)?\/\//.test(withoutTrailing)) {
+                return withoutTrailing;
+        }
+
+        console.warn(
+                `Ignoring invalid ASSETS_PATH value "${raw}". The assets path must be an absolute URL.`
+        );
+
+        return undefined;
 })();
 
 /** @type {import('@sveltejs/kit').Config} */
@@ -23,11 +41,11 @@ const config = {
 		adapter: adapter({
 			fallback: '200.html'
 		}),
-		paths: {
-			base: normalizedBasePath,
-			assets: normalizedBasePath
-		}
-	}
+                paths: {
+                        base: normalizedBasePath,
+                        ...(normalizedAssetsPath ? { assets: normalizedAssetsPath } : {})
+                }
+        }
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- reuse the loaded environment when computing the normalized base path
- normalize the optional ASSETS_PATH value and only apply it when it is an absolute URL

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dc685ae1348327b8637ccfedcad0bf